### PR TITLE
Use the actually documented defaults in the cloudscale_server resource

### DIFF
--- a/cloudscale/resource_cloudscale_server.go
+++ b/cloudscale/resource_cloudscale_server.go
@@ -156,17 +156,17 @@ func getServerSchema() map[string]*schema.Schema {
 			Computed: true,
 		},
 		"ssh_fingerprints": {
-			Type:     schema.TypeSet,
+			Type:     schema.TypeList,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 			Computed: true,
 		},
 		"ssh_host_keys": {
-			Type:     schema.TypeSet,
+			Type:     schema.TypeList,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 			Computed: true,
 		},
 		"anti_affinity_with": {
-			Type:     schema.TypeSet,
+			Type:     schema.TypeList,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 			Computed: true,
 		},

--- a/cloudscale/resource_cloudscale_server.go
+++ b/cloudscale/resource_cloudscale_server.go
@@ -96,7 +96,7 @@ func getServerSchema() map[string]*schema.Schema {
 			Computed: true,
 		},
 		"volumes": {
-			Type: schema.TypeSet,
+			Type: schema.TypeList,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"type": {
@@ -116,7 +116,7 @@ func getServerSchema() map[string]*schema.Schema {
 			Computed: true,
 		},
 		"interfaces": {
-			Type: schema.TypeSet,
+			Type: schema.TypeList,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"type": {

--- a/cloudscale/resource_cloudscale_server.go
+++ b/cloudscale/resource_cloudscale_server.go
@@ -75,6 +75,7 @@ func getServerSchema() map[string]*schema.Schema {
 			Type:     schema.TypeBool,
 			Optional: true,
 			ForceNew: true,
+			Default:  true,
 		},
 		"use_private_network": {
 			Type:     schema.TypeBool,
@@ -85,6 +86,7 @@ func getServerSchema() map[string]*schema.Schema {
 			Type:     schema.TypeBool,
 			Optional: true,
 			ForceNew: true,
+			Default:  true,
 		},
 
 		// Computed attributes
@@ -175,6 +177,7 @@ func getServerSchema() map[string]*schema.Schema {
 		},
 	}
 }
+
 func resourceServerCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudscale.Client)
 
@@ -201,19 +204,17 @@ func resourceServerCreate(d *schema.ResourceData, meta interface{}) error {
 		opts.BulkVolumeSizeGB = attr.(int)
 	}
 
-	if attr, ok := d.GetOk("use_public_network"); ok {
-		val := attr.(bool)
-		opts.UsePublicNetwork = &val
-	}
+	use_public_network := d.Get("use_public_network")
+	use_public_network_bool := use_public_network.(bool)
+	opts.UsePublicNetwork = &use_public_network_bool
+
+	use_ipv6 := d.Get("use_ipv6")
+	use_ipv6_bool := use_ipv6.(bool)
+	opts.UseIPV6 = &use_ipv6_bool
 
 	if attr, ok := d.GetOk("use_private_network"); ok {
 		val := attr.(bool)
 		opts.UsePrivateNetwork = &val
-	}
-
-	if attr, ok := d.GetOk("use_ipv6"); ok {
-		val := attr.(bool)
-		opts.UseIPV6 = &val
 	}
 
 	if attr, ok := d.GetOk("anti_affinity_uuid"); ok {

--- a/cloudscale/resource_cloudscale_server.go
+++ b/cloudscale/resource_cloudscale_server.go
@@ -75,7 +75,6 @@ func getServerSchema() map[string]*schema.Schema {
 			Type:     schema.TypeBool,
 			Optional: true,
 			ForceNew: true,
-			Default:  true,
 		},
 		"use_private_network": {
 			Type:     schema.TypeBool,
@@ -86,7 +85,6 @@ func getServerSchema() map[string]*schema.Schema {
 			Type:     schema.TypeBool,
 			Optional: true,
 			ForceNew: true,
-			Default:  true,
 		},
 
 		// Computed attributes
@@ -204,17 +202,19 @@ func resourceServerCreate(d *schema.ResourceData, meta interface{}) error {
 		opts.BulkVolumeSizeGB = attr.(int)
 	}
 
-	use_public_network := d.Get("use_public_network")
-	use_public_network_bool := use_public_network.(bool)
-	opts.UsePublicNetwork = &use_public_network_bool
+	if attr, ok := d.GetOkExists("use_public_network"); ok {
+		val := attr.(bool)
+		opts.UsePublicNetwork = &val
+	}
 
-	use_ipv6 := d.Get("use_ipv6")
-	use_ipv6_bool := use_ipv6.(bool)
-	opts.UseIPV6 = &use_ipv6_bool
-
-	if attr, ok := d.GetOk("use_private_network"); ok {
+	if attr, ok := d.GetOkExists("use_private_network"); ok {
 		val := attr.(bool)
 		opts.UsePrivateNetwork = &val
+	}
+
+	if attr, ok := d.GetOkExists("use_ipv6"); ok {
+		val := attr.(bool)
+		opts.UseIPV6 = &val
 	}
 
 	if attr, ok := d.GetOk("anti_affinity_uuid"); ok {

--- a/cloudscale/resource_cloudscale_server_test.go
+++ b/cloudscale/resource_cloudscale_server_test.go
@@ -216,8 +216,6 @@ func TestAccCloudscaleServer_Recreated(t *testing.T) {
 }
 
 func TestAccCloudscaleServer_PrivateNetwork(t *testing.T) {
-	var afterCreate, afterUpdate cloudscale.Server
-
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
@@ -228,12 +226,12 @@ func TestAccCloudscaleServer_PrivateNetwork(t *testing.T) {
 			{
 				Config: testAccCheckCloudscaleServerConfig_only_private_network(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudscaleServerExists("cloudscale_server.private", &afterUpdate),
 					resource.TestCheckResourceAttr(
 						"cloudscale_server.private", "name", fmt.Sprintf("terraform-%d", rInt)),
 					resource.TestCheckResourceAttr(
+						"cloudscale_server.private", "interfaces.#", "1"),
+					resource.TestCheckResourceAttr(
 						"cloudscale_server.private", "interfaces.0.type", "private"),
-					testAccCheckServerRecreated(t, &afterCreate, &afterUpdate),
 				),
 			},
 		},

--- a/cloudscale/resource_cloudscale_server_test.go
+++ b/cloudscale/resource_cloudscale_server_test.go
@@ -208,6 +208,8 @@ func TestAccCloudscaleServer_Recreated(t *testing.T) {
 						"cloudscale_server.basic", "name", fmt.Sprintf("terraform-%d", rInt)),
 					resource.TestCheckResourceAttr(
 						"cloudscale_server.basic", "flavor_slug", "flex-4"),
+					resource.TestCheckResourceAttr(
+						"cloudscale_server.basic", "interfaces.#", "2"),
 					testAccCheckServerRecreated(t, &afterCreate, &afterUpdate),
 				),
 			},
@@ -418,6 +420,7 @@ resource "cloudscale_server" "basic" {
   name      			    = "terraform-%d"
   flavor_slug    			= "flex-4"
   image_slug     			= "debian-8"
+  use_private_network		= true
   volume_size_gb			= 10
   ssh_keys 						= ["ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFEepRNW5hDct4AdJ8oYsb4lNP5E9XY5fnz3ZvgNCEv7m48+bhUjJXUPuamWix3zigp2lgJHC6SChI/okJ41GUY="]
 }`, rInt)


### PR DESCRIPTION
If using use_private_network = False or use_ipv6 = False the default was still
always true, because we checked it with ResourceData.GetOk, which only returns
ok if the value is non-zero. One possible fix in the future would have been to
use ResourceData.GetOkExists instead. However this method only exists on the
master branch and not in any current terraform release. Therefore we are just
using defaults and ResourceData.Get.

Added a test to avoid the issue in the future.

I'm not a go programmer so please let me know if there are issues in here.