### PR TITLE
Expose IP addresses as plain strings (fixes #7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 IMPROVEMENTS:
 
 * Expose the first public/private IPv4 and IPv6 addresses as string attributes `public_ipv4`,
-  `public_ipv6`, `private_ipv4` and `private_ipv6`
+  `public_ipv6` and `private_ipv4`
 
 ## 1.0.1 (April 06, 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 ## 1.0.2 (Unreleased)
+
+
+IMPROVEMENTS:
+
+* Expose the first public/private IPv4 and IPv6 addresses as string attributes `public_ipv4`,
+  `public_ipv6`, `private_ipv4` and `private_ipv6`
+
 ## 1.0.1 (April 06, 2018)
 
 

--- a/cloudscale/resource_cloudscale_server.go
+++ b/cloudscale/resource_cloudscale_server.go
@@ -113,6 +113,22 @@ func getServerSchema() map[string]*schema.Schema {
 			},
 			Computed: true,
 		},
+		"public_ipv4": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"public_ipv6": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"private_ipv4": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"private_ipv6": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 		"interfaces": {
 			Type: schema.TypeList,
 			Elem: &schema.Resource{
@@ -365,6 +381,11 @@ func resourceServerRead(d *schema.ResourceData, meta interface{}) error {
 			})
 		}
 	}
+
+	d.Set("public_ipv4", findIPv4AddrByType(server, "public"))
+	d.Set("public_ipv6", findIPv6AddrByType(server, "public"))
+	d.Set("private_ipv4", findIPv4AddrByType(server, "private"))
+	d.Set("private_ipv6", findIPv6AddrByType(server, "private"))
 
 	return nil
 }

--- a/cloudscale/resource_cloudscale_server.go
+++ b/cloudscale/resource_cloudscale_server.go
@@ -113,19 +113,15 @@ func getServerSchema() map[string]*schema.Schema {
 			},
 			Computed: true,
 		},
-		"public_ipv4": {
+		"public_ipv4_address": {
 			Type:     schema.TypeString,
 			Computed: true,
 		},
-		"public_ipv6": {
+		"public_ipv6_address": {
 			Type:     schema.TypeString,
 			Computed: true,
 		},
-		"private_ipv4": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"private_ipv6": {
+		"private_ipv4_address": {
 			Type:     schema.TypeString,
 			Computed: true,
 		},
@@ -382,10 +378,9 @@ func resourceServerRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	d.Set("public_ipv4", findIPv4AddrByType(server, "public"))
-	d.Set("public_ipv6", findIPv6AddrByType(server, "public"))
-	d.Set("private_ipv4", findIPv4AddrByType(server, "private"))
-	d.Set("private_ipv6", findIPv6AddrByType(server, "private"))
+	d.Set("public_ipv4_address", findIPv4AddrByType(server, "public"))
+	d.Set("public_ipv6_address", findIPv6AddrByType(server, "public"))
+	d.Set("private_ipv4_address", findIPv4AddrByType(server, "private"))
 
 	return nil
 }

--- a/cloudscale/resource_cloudscale_server_test.go
+++ b/cloudscale/resource_cloudscale_server_test.go
@@ -351,22 +351,17 @@ func testAccCheckServerIp(n string) resource.TestCheckFunc {
 		for _, networkInterface := range retrieveServer.Interfaces {
 			for _, ipAddress := range networkInterface.Adresses {
 				if ipAddress.Version == 4 && networkInterface.Type == "public" {
-					err := resource.TestCheckResourceAttr(n, "public_ipv4", ipAddress.Address)(s)
+					err := resource.TestCheckResourceAttr(n, "public_ipv4_address", ipAddress.Address)(s)
 					if err != nil {
 						return err
 					}
 				} else if ipAddress.Version == 4 && networkInterface.Type == "private" {
-					err := resource.TestCheckResourceAttr(n, "private_ipv4", ipAddress.Address)(s)
+					err := resource.TestCheckResourceAttr(n, "private_ipv4_address", ipAddress.Address)(s)
 					if err != nil {
 						return err
 					}
 				} else if ipAddress.Version == 6 && networkInterface.Type == "public" {
-					err := resource.TestCheckResourceAttr(n, "public_ipv6", ipAddress.Address)(s)
-					if err != nil {
-						return err
-					}
-				} else if ipAddress.Version == 6 && networkInterface.Type == "private" {
-					err := resource.TestCheckResourceAttr(n, "private_ipv6", ipAddress.Address)(s)
+					err := resource.TestCheckResourceAttr(n, "public_ipv6_address", ipAddress.Address)(s)
 					if err != nil {
 						return err
 					}

--- a/cloudscale/resource_cloudscale_server_test.go
+++ b/cloudscale/resource_cloudscale_server_test.go
@@ -70,6 +70,7 @@ func TestAccCloudscaleServer_Basic(t *testing.T) {
 						"cloudscale_server.basic", "image_slug", "debian-8"),
 					resource.TestCheckResourceAttr(
 						"cloudscale_server.basic", "interfaces.0.type", "public"),
+					testAccCheckServerIp("cloudscale_server.basic"),
 				),
 			},
 		},
@@ -149,6 +150,7 @@ func TestAccCloudscaleServer_Update(t *testing.T) {
 						"cloudscale_server.basic", "flavor_slug", "flex-2"),
 					resource.TestCheckResourceAttr(
 						"cloudscale_server.basic", "image_slug", "debian-8"),
+					testAccCheckServerIp("cloudscale_server.basic"),
 				),
 			},
 			{
@@ -170,6 +172,7 @@ func TestAccCloudscaleServer_Update(t *testing.T) {
 						"cloudscale_server.basic", "name", fmt.Sprintf("terraform-%d", rInt)),
 					resource.TestCheckResourceAttr(
 						"cloudscale_server.basic", "status", "running"),
+					testAccCheckServerIp("cloudscale_server.basic"),
 					testAccCheckServerChanged(t, &afterCreate, &afterUpdate),
 				),
 			},
@@ -198,6 +201,7 @@ func TestAccCloudscaleServer_Recreated(t *testing.T) {
 						"cloudscale_server.basic", "flavor_slug", "flex-2"),
 					resource.TestCheckResourceAttr(
 						"cloudscale_server.basic", "image_slug", "debian-8"),
+					testAccCheckServerIp("cloudscale_server.basic"),
 				),
 			},
 			{
@@ -210,6 +214,7 @@ func TestAccCloudscaleServer_Recreated(t *testing.T) {
 						"cloudscale_server.basic", "flavor_slug", "flex-4"),
 					resource.TestCheckResourceAttr(
 						"cloudscale_server.basic", "interfaces.#", "2"),
+					testAccCheckServerIp("cloudscale_server.basic"),
 					testAccCheckServerRecreated(t, &afterCreate, &afterUpdate),
 				),
 			},
@@ -234,6 +239,7 @@ func TestAccCloudscaleServer_PrivateNetwork(t *testing.T) {
 						"cloudscale_server.private", "interfaces.#", "1"),
 					resource.TestCheckResourceAttr(
 						"cloudscale_server.private", "interfaces.0.type", "private"),
+					testAccCheckServerIp("cloudscale_server.private"),
 				),
 			},
 		},
@@ -312,6 +318,61 @@ func testAccCheckCloudscaleServerAttributes(server *cloudscale.Server) resource.
 			return fmt.Errorf("Bad volumes_size_gb: %d", server.Volumes[0].SizeGB)
 		}
 
+		return nil
+	}
+}
+
+func testAccCheckServerIp(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Server ID is set")
+		}
+
+		client := testAccProvider.Meta().(*cloudscale.Client)
+
+		id := rs.Primary.ID
+
+		// Try to find the server
+		retrieveServer, err := client.Servers.Get(context.Background(), id)
+
+		if err != nil {
+			return err
+		}
+
+		if retrieveServer.UUID != rs.Primary.ID {
+			return fmt.Errorf("Server not found")
+		}
+
+		for _, networkInterface := range retrieveServer.Interfaces {
+			for _, ipAddress := range networkInterface.Adresses {
+				if ipAddress.Version == 4 && networkInterface.Type == "public" {
+					err := resource.TestCheckResourceAttr(n, "public_ipv4", ipAddress.Address)(s)
+					if err != nil {
+						return err
+					}
+				} else if ipAddress.Version == 4 && networkInterface.Type == "private" {
+					err := resource.TestCheckResourceAttr(n, "private_ipv4", ipAddress.Address)(s)
+					if err != nil {
+						return err
+					}
+				} else if ipAddress.Version == 6 && networkInterface.Type == "public" {
+					err := resource.TestCheckResourceAttr(n, "public_ipv6", ipAddress.Address)(s)
+					if err != nil {
+						return err
+					}
+				} else if ipAddress.Version == 6 && networkInterface.Type == "private" {
+					err := resource.TestCheckResourceAttr(n, "private_ipv6", ipAddress.Address)(s)
+					if err != nil {
+						return err
+					}
+				}
+			}
+		}
 		return nil
 	}
 }

--- a/website/docs/r/server.html.markdown
+++ b/website/docs/r/server.html.markdown
@@ -61,7 +61,6 @@ In addition to the arguments listed above, the following computed attributes are
 * `public_ipv4` - The first `public` IPv4 address of this server. The returned IP address may be `""` if the server does not have a public IPv4.
 * `private_ipv4` - The first `private` IPv4 address of this server. The returned IP address may be `""` if the server does not have private networking enabled.
 * `public_ipv6` - The first `public` IPv6 address of this server. The returned IP address may be `""` if the server does not have a public IPv6.
-* `private_ipv6` - The first `private` IPv6 address of this server. The returned IP address may be `""` if the server does not have private networking enabled.
 * `interfaces` - A list of interface objects attached to this server. Each interface object has two attributes:
     * `type` - Either `public` or `private`. Public interfaces are connected to the Internet, while private interfaces are not.
     * `addresses` - A list of address objects:

--- a/website/docs/r/server.html.markdown
+++ b/website/docs/r/server.html.markdown
@@ -58,6 +58,10 @@ In addition to the arguments listed above, the following computed attributes are
     * `device_path` - The path (string) to the volume on your server (e.g. `/dev/vda`)
     * `size_gb` - The size (int) of the volume in GB. Typically matches `volume_size_gb` or `bulk_volume_size_gb`.
     * `type` - A string. Either `ssd` or `bulk`.
+* `public_ipv4` - The first `public` IPv4 address of this server. The returned IP address may be `""` if the server does not have a public IPv4.
+* `private_ipv4` - The first `private` IPv4 address of this server. The returned IP address may be `""` if the server does not have private networking enabled.
+* `public_ipv6` - The first `public` IPv6 address of this server. The returned IP address may be `""` if the server does not have a public IPv6.
+* `private_ipv6` - The first `private` IPv6 address of this server. The returned IP address may be `""` if the server does not have private networking enabled.
 * `interfaces` - A list of interface objects attached to this server. Each interface object has two attributes:
     * `type` - Either `public` or `private`. Public interfaces are connected to the Internet, while private interfaces are not.
     * `addresses` - A list of address objects:


### PR DESCRIPTION
The additional attributes enable easier access to a server's IP addresses, for example to deploy DNS records. See #7.

I wasn't entirely sure about the best way to write acceptance tests for this. I hope that my implementation in `cloudscale/resource_cloudscale_server_test.go` makes sense for a terraform provider.