### PR TITLE
Use http status code for not found detection

### DIFF
--- a/cloudscale/resource_cloudscale_server.go
+++ b/cloudscale/resource_cloudscale_server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"strings"
 	"time"
 
 	"github.com/cloudscale-ch/cloudscale-go-sdk"
@@ -268,12 +267,7 @@ func resourceServerRead(d *schema.ResourceData, meta interface{}) error {
 
 	server, err := client.Servers.Get(context.Background(), id)
 	if err != nil {
-		if err.Error() == "detail: Not Found." {
-			log.Printf("[WARN] Cloudscale Server (%s) not found", d.Id())
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf("Error retrieving server: %s", err)
+		return CheckDeleted(d, err, "Error retrieving server")
 	}
 
 	d.Set("href", server.HREF)
@@ -406,17 +400,9 @@ func resourceServerDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Deleting Server: %s", d.Id())
 	err := client.Servers.Delete(context.Background(), id)
 
-	if err != nil && strings.Contains(err.Error(), "Not found") {
-		log.Printf("[WARN] Cloudscale Server (%s) not found", d.Id())
-		d.SetId("")
-		return nil
-	}
-
 	if err != nil {
-		return fmt.Errorf("Error deleting Server: %s", err)
+		return CheckDeleted(d, err, "Error deleting Server")
 	}
-
-	d.SetId("")
 
 	return nil
 }

--- a/cloudscale/util.go
+++ b/cloudscale/util.go
@@ -1,0 +1,19 @@
+package cloudscale
+
+import (
+	"fmt"
+	"github.com/cloudscale-ch/cloudscale-go-sdk"
+	"github.com/hashicorp/terraform/helper/schema"
+	"net/http"
+)
+
+// CheckDeleted checks the error to see if it's a 404 (Not Found) and, if so,
+// sets the resource ID to the empty string instead of throwing an error.
+func CheckDeleted(d *schema.ResourceData, err error, msg string) error {
+	errorResponse, ok := err.(*cloudscale.ErrorResponse)
+	if ok && errorResponse.StatusCode == http.StatusNotFound {
+		d.SetId("")
+		return nil
+	}
+	return fmt.Errorf("%s %s: %s", msg, d.Id(), err)
+}

--- a/vendor/github.com/cloudscale-ch/cloudscale-go-sdk/LICENSE
+++ b/vendor/github.com/cloudscale-ch/cloudscale-go-sdk/LICENSE
@@ -1,0 +1,46 @@
+This library is MIT licensed. Parts of the metadata stuff has been copied from
+DigitalOcean and are therefore also MIT licensed, see below:
+
+--------------
+
+Copyright (c) cloudscale.ch AG
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+--------------
+The MIT License (MIT)
+
+Copyright (c) 2015 DigitalOcean
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/cloudscale-ch/cloudscale-go-sdk/Makefile
+++ b/vendor/github.com/cloudscale-ch/cloudscale-go-sdk/Makefile
@@ -1,0 +1,15 @@
+TEST?=$$(go list ./... |grep -v 'vendor')
+
+test:
+	go test $(TEST) $(TESTARGS) -timeout 30s
+
+integration:
+	go get github.com/cenkalti/backoff
+	go get golang.org/x/oauth2
+	go test -tags=integration -v $(TEST)/test/integration/... $(TESTARGS) -timeout 120m
+
+fmt:
+	go fmt
+	gofmt -l -w test/integration
+
+.PHONY: test integration

--- a/vendor/github.com/cloudscale-ch/cloudscale-go-sdk/README.md
+++ b/vendor/github.com/cloudscale-ch/cloudscale-go-sdk/README.md
@@ -1,0 +1,33 @@
+# cloudscale.ch Go API SDK
+
+If you want to manage your cloudscale.ch server resources with Go, you are at
+the right place.
+
+There's a possibility to specify the `CLOUDSCALE_URL` environment variable to
+change the default url of https://api.cloudscale.ch.
+
+## Testing
+
+The test directory contains integration tests, aside from the unit tests in the
+root directory. While the unit tests suite runs very quickly because they
+don't make any network calls, this can take some time to run.
+
+### test/integration
+
+This folder contains tests for every type of operation in the cloudscale.ch API
+and runs tests against it.
+
+Since the tests are run against live data, there is a higher chance of false
+positives and test failures due to network issues, data changes, etc.
+
+Run the tests using:
+
+````
+CLOUDSCALE_TOKEN="HELPIMTRAPPEDINATOKENGENERATOR" make integration
+
+````
+
+If you want to give params to `go test`, you can use something like this:
+```
+TESTARGS='-run FloatingIP' make integration
+```

--- a/vendor/github.com/cloudscale-ch/cloudscale-go-sdk/metadata.go
+++ b/vendor/github.com/cloudscale-ch/cloudscale-go-sdk/metadata.go
@@ -1,0 +1,124 @@
+// Package metadata implements a client for the cloudscale.ch's OpenStack
+// metadata API. This API allows a server to inspect information about itself,
+// like its server ID.
+//
+// Documentation for the API is available at:
+//
+//    https://www.cloudscale.ch/en/api/v1
+package cloudscale
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"path"
+	"time"
+	"errors"
+)
+
+const (
+	maxErrMsgLen = 128 // arbitrary max length for error messages
+
+	defaultTimeout = 2 * time.Second
+	defaultPath    = "/openstack/2017-02-22/"
+)
+
+var (
+	defaultMetadataBaseURL = func() *url.URL {
+		u, err := url.Parse("http://169.254.169.254")
+		if err != nil {
+			panic(err)
+		}
+		return u
+	}()
+)
+
+// Client to interact with cloudscale.ch's OpenStack metadata API, from inside
+// a server.
+type MetadataClient struct {
+	client  *http.Client
+	BaseURL *url.URL
+}
+
+// NewClient creates a client for the metadata API.
+func NewMetadataClient(httpClient *http.Client) *MetadataClient {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	client := &MetadataClient{
+		client:  &http.Client{Timeout: defaultTimeout},
+		BaseURL: defaultMetadataBaseURL,
+	}
+	return client
+}
+
+// Metadata contains the entire contents of a OpenStack's metadata.
+// This method is unique because it returns all of the
+// metadata at once, instead of individual metadata items.
+func (c *MetadataClient) GetMetadata() (*Metadata, error) {
+	metadata := new(Metadata)
+	err := c.getResource("meta_data.json", func(r io.Reader) error {
+		return json.NewDecoder(r).Decode(metadata)
+	})
+	return metadata, err
+}
+
+// ServerID returns the Server's unique identifier. This is
+// automatically generated upon Server creation.
+func (c *MetadataClient) GetServerID() (string, error) {
+	metadata, err := c.GetMetadata()
+	if err != nil {
+		return "", err
+	}
+	if metadata.Meta.CloudscaleUUID == "" {
+		return "", errors.New("The CloudscaleUUID was not defined in metadata")
+	}
+	return metadata.Meta.CloudscaleUUID, nil
+}
+
+// RawUserData returns the user data that was provided by the user
+// during Server creation. User data for cloudscale.ch is a YAML
+// Script that is used for cloud-init.
+func (c *MetadataClient) GetRawUserData() (string, error) {
+	var userdata string
+	err := c.getResource("user_data", func(r io.Reader) error {
+		userdataraw, err := ioutil.ReadAll(r)
+		userdata = string(userdataraw)
+		return err
+	})
+	return userdata, err
+}
+
+func (c *MetadataClient) getResource(resource string, decoder func(r io.Reader) error) error {
+	url := c.resolve(defaultPath, resource)
+	resp, err := c.client.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return c.makeError(resp)
+	}
+	return decoder(resp.Body)
+}
+
+func (c *MetadataClient) makeError(resp *http.Response) error {
+	body, _ := ioutil.ReadAll(io.LimitReader(resp.Body, maxErrMsgLen))
+	if len(body) >= maxErrMsgLen {
+		body = append(body[:maxErrMsgLen], []byte("... (elided)")...)
+	} else if len(body) == 0 {
+		body = []byte(resp.Status)
+	}
+	return fmt.Errorf("unexpected response from metadata API, status %d: %s",
+		resp.StatusCode, string(body))
+}
+
+func (c *MetadataClient) resolve(basePath string, resource ...string) string {
+	dupe := *c.BaseURL
+	dupe.Path = path.Join(append([]string{basePath}, resource...)...)
+	return dupe.String()
+}

--- a/vendor/github.com/cloudscale-ch/cloudscale-go-sdk/metadata_json.go
+++ b/vendor/github.com/cloudscale-ch/cloudscale-go-sdk/metadata_json.go
@@ -1,0 +1,13 @@
+package cloudscale
+
+type Metadata struct {
+	AvailabilityZone string   `json:"availability_zone,omitempty"`
+	// For now don't define those, because they don't need to match the
+	// official cloudscale.ch API and are part of OpenStack.
+	//Hostname         string   `json:"hostname,omitempty"`
+	//Name             string   `json:"user_data,omitempty"`
+
+	Meta struct {
+		CloudscaleUUID string `json:"cloudscale_uuid,omitempty"`
+	} `json:"meta,omitempty"`
+}

--- a/vendor/github.com/cloudscale-ch/cloudscale-go-sdk/secrets.sh
+++ b/vendor/github.com/cloudscale-ch/cloudscale-go-sdk/secrets.sh
@@ -1,0 +1,2 @@
+CLOUDSCALE_URL=https://staging-api.cloudscale.ch/
+CLOUDSCALE_TOKEN=2xudbruth6nriglssuqkm4krsk5azrxw

--- a/vendor/github.com/cloudscale-ch/cloudscale-go-sdk/secrets.sh
+++ b/vendor/github.com/cloudscale-ch/cloudscale-go-sdk/secrets.sh
@@ -1,2 +1,0 @@
-CLOUDSCALE_URL=https://staging-api.cloudscale.ch/
-CLOUDSCALE_TOKEN=2xudbruth6nriglssuqkm4krsk5azrxw

--- a/vendor/github.com/cloudscale-ch/cloudscale-go-sdk/servers.go
+++ b/vendor/github.com/cloudscale-ch/cloudscale-go-sdk/servers.go
@@ -19,7 +19,7 @@ type Server struct {
 	Status          string       `json:"status"`
 	Flavor          Flavor       `json:"flavor"`
 	Image           Image        `json:"image"`
-	Volumes         []Volume     `json:"volumes"`
+	Volumes         []VolumeStub `json:"volumes"`
 	Interfaces      []Interface  `json:"interfaces"`
 	SSHFingerprints []string     `json:"ssh_fingerprints"`
 	SSHHostKeys     []string     `json:"ssh_host_keys"`
@@ -44,7 +44,7 @@ type Image struct {
 	OperatingSystem string `json:"operating_system"`
 }
 
-type Volume struct {
+type VolumeStub struct {
 	Type       string `json:"type"`
 	DevicePath string `json:"device_path"`
 	SizeGB     int    `json:"size_gb"`

--- a/vendor/github.com/cloudscale-ch/cloudscale-go-sdk/volumes.go
+++ b/vendor/github.com/cloudscale-ch/cloudscale-go-sdk/volumes.go
@@ -1,0 +1,116 @@
+package cloudscale
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+const volumeBasePath = "v1/volumes"
+
+type Volume struct {
+	// Just use omitempty everywhere. This makes it easy to use restful. Errors
+	// will be coming from the API if something is disabled.
+	HREF        string    `json:"href,omitempty"`
+	UUID        string    `json:"uuid,omitempty"`
+	Name        string    `json:"name,omitempty"`
+	SizeGB      int       `json:"size_gb,omitempty"`
+	Type        string    `json:"type,omitempty"`
+	ServerUUIDs *[]string `json:"server_uuids,omitempty"`
+}
+
+type ListVolumeParams struct {
+	Name string `json:"name,omitempty"`
+}
+
+type VolumeService interface {
+	Create(ctx context.Context, createRequest *Volume) (*Volume, error)
+	Get(ctx context.Context, volumeID string) (*Volume, error)
+	List(ctx context.Context, params *ListVolumeParams) ([]Volume, error)
+	Update(ctx context.Context, volumeID string, updateRequest *Volume) error
+	Delete(ctx context.Context, volumeID string) error
+}
+
+type VolumeServiceOperations struct {
+	client *Client
+}
+
+func (s VolumeServiceOperations) Create(ctx context.Context, createRequest *Volume) (*Volume, error) {
+	path := volumeBasePath
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, createRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	volume := new(Volume)
+
+	err = s.client.Do(ctx, req, volume)
+	if err != nil {
+		return nil, err
+	}
+
+	return volume, nil
+}
+
+func (f VolumeServiceOperations) Update(ctx context.Context, volumeID string, updateRequest *Volume) error {
+	path := fmt.Sprintf("%s/%s", volumeBasePath, volumeID)
+
+	req, err := f.client.NewRequest(ctx, http.MethodPatch, path, updateRequest)
+	if err != nil {
+		return err
+	}
+
+	err = f.client.Do(ctx, req, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s VolumeServiceOperations) Get(ctx context.Context, volumeID string) (*Volume, error) {
+	path := fmt.Sprintf("%s/%s", volumeBasePath, volumeID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	volume := new(Volume)
+	err = s.client.Do(ctx, req, volume)
+	if err != nil {
+		return nil, err
+	}
+
+	return volume, nil
+}
+
+func (s VolumeServiceOperations) Delete(ctx context.Context, volumeID string) error {
+	path := fmt.Sprintf("%s/%s", volumeBasePath, volumeID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return err
+	}
+	return s.client.Do(ctx, req, nil)
+}
+
+func (s VolumeServiceOperations) List(ctx context.Context, params *ListVolumeParams) ([]Volume, error) {
+	path := volumeBasePath
+	if params != nil {
+		if params.Name != "" {
+			path = fmt.Sprintf("%s?name=%s", path, params.Name)
+		}
+	}
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	volumes := []Volume{}
+	err = s.client.Do(ctx, req, &volumes)
+	if err != nil {
+		return nil, err
+	}
+
+	return volumes, nil
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -227,7 +227,7 @@
 			"revisionTime": "2018-04-03T17:12:35Z"
 		},
 		{
-			"checksumSHA1": "eA/y8rNtAI0oOoAbCwfcgeaTSqk=",
+			"checksumSHA1": "2PcDfO8049mLQUr091Sg0Ta/g8s=",
 			"path": "github.com/cloudscale-ch/cloudscale-go-sdk",
 			"revision": "17fbddda00c87b73c5ceb601aeaced294748231b",
 			"revisionTime": "2018-09-26T13:12:23Z"

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -227,10 +227,10 @@
 			"revisionTime": "2018-04-03T17:12:35Z"
 		},
 		{
-			"checksumSHA1": "kv1j54Piu7dw6hzVUXBliREzTyI=",
+			"checksumSHA1": "eA/y8rNtAI0oOoAbCwfcgeaTSqk=",
 			"path": "github.com/cloudscale-ch/cloudscale-go-sdk",
-			"revision": "f4c45b3d15cdf8180af42b4579b3e275a63f9e09",
-			"revisionTime": "2017-08-11T16:36:57Z"
+			"revision": "17fbddda00c87b73c5ceb601aeaced294748231b",
+			"revisionTime": "2018-09-26T13:12:23Z"
 		},
 		{
 			"checksumSHA1": "/5cvgU+J4l7EhMXTK76KaCAfOuU=",


### PR DESCRIPTION
This fixes #9. 

I cherry-picked @davidhalter's updates to the cloudscale-go-sdk from PR #5, because this PR needs the updated sdk to access the HTTP status code returned by the API.

I am reusing the pattern that the OpenStack terraform provider uses for checking if a resource is deleted, see [terraform-provider-openstack/openstack/util.go](https://github.com/terraform-providers/terraform-provider-openstack/blob/master/openstack/util.go) and [terraform-provider-openstack/openstack/resource_openstack_compute_instance_v2.go#L549](https://github.com/terraform-providers/terraform-provider-openstack/blob/master/openstack/resource_openstack_compute_instance_v2.go#L549)

If I delete a server from the cloudscale.ch account and run `terraform plan`, terraform no longer returns an error but indicates that the resource needs to be created (not recreated).

I was unable to write an acceptance test for this, because it is unclear to me how I could call the cloudscale.ch API in a `TestStep`.