### PR TITLE
provider: Enable request/response logging

### DIFF
--- a/cloudscale/config.go
+++ b/cloudscale/config.go
@@ -2,6 +2,7 @@ package cloudscale
 
 import (
 	"github.com/cloudscale-ch/cloudscale-go-sdk"
+	"github.com/hashicorp/terraform/helper/logging"
 	"golang.org/x/oauth2"
 )
 
@@ -10,10 +11,12 @@ type Config struct {
 }
 
 func (c *Config) Client() (*cloudscale.Client, error) {
-
 	tc := oauth2.NewClient(oauth2.NoContext, oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: c.Token},
 	))
+
+	tc.Transport = logging.NewTransport("Cloudscale", tc.Transport)
+
 	client := cloudscale.NewClient(tc)
 
 	return client, nil


### PR DESCRIPTION
This makes debugging for developers & users of this provider easier by exposing all requests & responses in the log (when >`DEBUG` severity is set).

Example:

```
---[ REQUEST ]---------------------------------------
GET /v1/servers/af54f37e-2282-441b-9b4d-aced95575dc2 HTTP/1.1
Host: api.cloudscale.ch
User-Agent: cloudscale/1.0
Accept: application/json
Content-Type: application/json
Accept-Encoding: gzip


-----------------------------------------------------
2019/02/23 08:02:53 [DEBUG] Cloudscale API Response Details:
---[ RESPONSE ]--------------------------------------
HTTP/2.0 200 OK
Access-Control-Allow-Headers: Content-Type,Authorization
Access-Control-Allow-Methods: GET, POST, OPTIONS, PUT, PATCH, DELETE
Access-Control-Allow-Origin: *
Allow: GET, PATCH, DELETE, HEAD, OPTIONS
Content-Language: en
Content-Type: application/json
Date: Sat, 23 Feb 2019 08:02:53 GMT
Referrer-Policy: same-origin
Server: nginx
Strict-Transport-Security: max-age=15768000; includeSubDomains
Vary: Accept-Encoding
Vary: Accept-Encoding
Vary: Accept-Language, Cookie
X-Content-Type-Options: nosniff
X-Frame-Options: DENY
X-Xss-Protection: 1; mode=block

{
  "href": "https://api.cloudscale.ch/v1/servers/af54f37e-2282-441b-9b4d-aced95575dc2",
  "uuid": "af54f37e-2282-441b-9b4d-aced95575dc2",
  "name": "terraform-8802152773014700083",
  "status": "running",
  "flavor": {
    "slug": "flex-2",
    "name": "Flex-2",
    "vcpu_count": 1,
    "memory_gb": 2
  },
  "image": {
    "slug": "debian-8",
    "name": "Debian 8.7",
    "operating_system": "Debian",
    "default_username": "debian"
  },
  "volumes": [
    {
      "uuid": "b203430e-35fa-424a-9dd4-34aeae4d8c07",
      "name": "terraform-8802152773014700083-root",
      "size_gb": 10,
      "type": "ssd"
    }
  ],
  "interfaces": [
    {
      "type": "public",
      "addresses": [
        {
          "version": 4,
          "address": "5.102.147.85",
          "prefix_length": 24,
          "gateway": "5.102.147.1",
          "reverse_ptr": "5-102-147-85.cust.cloudscale.ch"
        },
        {
          "version": 6,
          "address": "2a06:c01:1:1104::9355:85",
          "prefix_length": 64,
          "gateway": "fe80::1",
          "reverse_ptr": "5-102-147-85.cust.cloudscale.ch"
        }
      ]
    }
  ],
  "ssh_fingerprints": null,
  "ssh_host_keys": null,
  "anti_affinity_with": []
}

-----------------------------------------------------
```