### PR TITLE
Scaling volume_size_gb without ForceNew

### DIFF
--- a/cloudscale/resource_cloudscale_server_test.go
+++ b/cloudscale/resource_cloudscale_server_test.go
@@ -248,7 +248,7 @@ func TestAccCloudscaleServer_PrivateNetwork(t *testing.T) {
 	})
 }
 
-func TestAccCloudscaleServer_UpdateNameAndFlavor(t *testing.T) {
+func TestAccCloudscaleServer_UpdateNameAndFlavorAndVolumeSize(t *testing.T) {
 	var afterCreate, afterUpdate cloudscale.Server
 
 	rInt := acctest.RandInt()
@@ -269,6 +269,8 @@ func TestAccCloudscaleServer_UpdateNameAndFlavor(t *testing.T) {
 						"cloudscale_server.basic", "flavor_slug", "flex-2"),
 					resource.TestCheckResourceAttr(
 						"cloudscale_server.basic", "status", "running"),
+					resource.TestCheckResourceAttr(
+						"cloudscale_server.basic", "volume_size_gb", "10"),
 					testAccCheckServerIp("cloudscale_server.basic"),
 				),
 			},
@@ -282,6 +284,8 @@ func TestAccCloudscaleServer_UpdateNameAndFlavor(t *testing.T) {
 						"cloudscale_server.basic", "name", fmt.Sprintf("terraform-%d-foobar", rInt)),
 					resource.TestCheckResourceAttr(
 						"cloudscale_server.basic", "status", "running"),
+					resource.TestCheckResourceAttr(
+						"cloudscale_server.basic", "volume_size_gb", "11"),
 					testAccCheckServerChanged(t, &afterCreate, &afterUpdate),
 				),
 			},
@@ -551,7 +555,7 @@ resource "cloudscale_server" "basic" {
   flavor_slug    			= "flex-4"
   allow_stopping_for_update = true
   image_slug     			= "%s"
-  volume_size_gb			= 10
+  volume_size_gb			= 11
   ssh_keys 						= ["ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFEepRNW5hDct4AdJ8oYsb4lNP5E9XY5fnz3ZvgNCEv7m48+bhUjJXUPuamWix3zigp2lgJHC6SChI/okJ41GUY=", "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFEepRNW5hDct4AdJ8oYsb4lNP5E9XY5fnz3ZvgNCEv7m48+bhUjJXUPuamWix3zigp2lgJHC6SChI/okJ41GUY="]
 }`, rInt, DefaultImageSlug)
 }

--- a/vendor/github.com/cloudscale-ch/cloudscale-go-sdk/servers.go
+++ b/vendor/github.com/cloudscale-ch/cloudscale-go-sdk/servers.go
@@ -48,6 +48,7 @@ type VolumeStub struct {
 	Type       string `json:"type"`
 	DevicePath string `json:"device_path"`
 	SizeGB     int    `json:"size_gb"`
+	UUID       string `json:"uuid"`
 }
 
 type Interface struct {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -227,10 +227,10 @@
 			"revisionTime": "2018-04-03T17:12:35Z"
 		},
 		{
-			"checksumSHA1": "bdPZIDg5irn0Uf6B+EyPvnutZoI=",
+			"checksumSHA1": "WvmlzNFfMFcpCKcH0KaQmOmOzp0=",
 			"path": "github.com/cloudscale-ch/cloudscale-go-sdk",
-			"revision": "df2fb1a7b50075d43a2f3767feb9dc8f9473f57b",
-			"revisionTime": "2019-04-03T14:23:09Z"
+			"revision": "d0e770f5e0611e32152cea3978964b7639343d27",
+			"revisionTime": "2019-04-08T09:35:28Z"
 		},
 		{
 			"checksumSHA1": "/5cvgU+J4l7EhMXTK76KaCAfOuU=",


### PR DESCRIPTION
As @ferdinandhuebner pointed out previously, it was not possible to scale a volume with ForceNew.

This PR changes this with a test as well. If possible it would be nice if you @ferdinandhuebner could review it again. Shouldn't be a big thing.