### PR TITLE
Check if region exists before accessing the region slug

### DIFF
--- a/cloudscale/resource_cloudscale_floating_ip.go
+++ b/cloudscale/resource_cloudscale_floating_ip.go
@@ -123,7 +123,9 @@ func resourceFloatingIPRead(d *schema.ResourceData, meta interface{}) error {
 	if floatingIP.Server != nil {
 		d.Set("server", floatingIP.Server.UUID)
 	}
-	d.Set("region_slug", floatingIP.Region.Slug)
+	if floatingIP.Region != nil {
+		d.Set("region_slug", floatingIP.Region.Slug)
+	}
 
 	return nil
 


### PR DESCRIPTION
Hey there!

Got some errors after upgrading to 2.2.0 today:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x19b63eb]

goroutine 135 [running]:
github.com/terraform-providers/terraform-provider-cloudscale/cloudscale.resourceFloatingIPRead(0xc00031c620, 0x1aea060, 0xc0003af600, 0xc00031c620, 0x0)
 /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-cloudscale/cloudscale/resource_cloudscale_floating_ip.go:126 +0x22b
github.com/hashicorp/terraform-plugin-sdk/helper/schema.(*Resource).RefreshWithoutUpgrade(0xc000148e80, 0xc0004741e0, 0x1aea060, 0xc0003af600, 0xc00017a1d0, 0x0, 0x0)
 /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-cloudscale/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/schema/resource.go:455 +0x119
github.com/hashicorp/terraform-plugin-sdk/internal/helper/plugin.(*GRPCProviderServer).ReadResource(0xc0000c29e0, 0x1e6c360, 0xc0005941b0, 0xc0004740f0, 0xc0000c29e0, 0xc0005941b0, 0xc000427bd0)
 /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-cloudscale/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/helper/plugin/grpc_provider.go:525 +0x3d7
github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5._Provider_ReadResource_Handler(0x1be5b20, 0xc0000c29e0, 0x1e6c360, 0xc0005941b0, 0xc00054a120, 0x0, 0x1e6c360, 0xc0005941b0, 0xc0005d8140, 0x130)
 /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-cloudscale/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5/tfplugin5.pb.go:3153 +0x23e
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0000f2000, 0x1e783c0, 0xc000540900, 0xc0004ea100, 0xc00015a390, 0x264f3f0, 0x0, 0x0, 0x0)
 /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-cloudscale/vendor/google.golang.org/grpc/server.go:995 +0x466
google.golang.org/grpc.(*Server).handleStream(0xc0000f2000, 0x1e783c0, 0xc000540900, 0xc0004ea100, 0x0)
 /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-cloudscale/vendor/google.golang.org/grpc/server.go:1275 +0xda6
google.golang.org/grpc.(*Server).serveStreams.func1.1(0xc000458c80, 0xc0000f2000, 0x1e783c0, 0xc000540900, 0xc0004ea100)
 /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-cloudscale/vendor/google.golang.org/grpc/server.go:710 +0x9f
created by google.golang.org/grpc.(*Server).serveStreams.func1
 /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-cloudscale/vendor/google.golang.org/grpc/server.go:708 +0xa1
```

After checking the corresponding code, I assume it fails because we have a floating IPv6 address that is not assigned to a region (defined as "global"). After applying this change, Terraform ran successfully. I would have included a test, but I saw that these are acceptance tests that require testing against a real account.