### PR TITLE
Small Improvements for CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,13 +30,9 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2.3.3
 
-    - name: Get dependencies
-      run: |
-        go mod download
-
     - name: Build
       run: |
-        go build -v .
+        go build -mod=vendor -v .
 
   # run acceptance tests in a matrix with Terraform core versions
   test:
@@ -64,10 +60,6 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2.3.3
 
-    - name: Get dependencies
-      run: |
-        go mod download
-
     - name: TF acceptance tests
       timeout-minutes: 120
       env:
@@ -82,4 +74,4 @@ jobs:
       if: env.CLOUDSCALE_TOKEN != null
 
       run: |
-        go test ./... -v -timeout 120m
+        go test -mod=vendor ./... -v -timeout 120m

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,6 +13,7 @@ builds:
   mod_timestamp: '{{ .CommitTimestamp }}'
   flags:
     - -trimpath
+    - -mod=vendor
   ldflags:
     - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
   goos:
@@ -38,7 +39,7 @@ checksum:
 signs:
   - artifacts: checksum
     args:
-      # if you are using this is a GitHub action or some other automated pipeline, you 
+      # if you are using this is a GitHub action or some other automated pipeline, you
       # need to pass the batch flag to indicate its not interactive.
       - "--batch"
       - "--local-user"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,6 +49,7 @@ signs:
       - "--detach-sign"
       - "${artifact}"
 release:
+  prerelease: auto
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
 changelog:


### PR DESCRIPTION
 * Add `-mod=vendor` flags.
 * Ensure GoReleaser marks prereleases as drafts on GitHub.