### PR TITLE
Ignore import_source_format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
  * Support for cloudscale.ch [Loads Balancers](https://www.cloudscale.ch/en/api/v1#load-balancers).
+ * Ignore `import_source_format` as it has been deprecated in the cloudscale.ch API.
+   You can remove the attribute from your Terraform file if you wish. The suggested
+   in-place upgrades are a no-ops.
 
 ## 4.1.0
  * Add firmware_type to custom_image.

--- a/cloudscale/datasource_cloudscale_custom_image_test.go
+++ b/cloudscale/datasource_cloudscale_custom_image_test.go
@@ -145,7 +145,6 @@ func customImageConfig_baseline(count int, rInt int) string {
 resource "cloudscale_custom_image" "basic" {
   count        = "%v"
   import_url         = "%s"
-  import_source_format      = "raw"
   name               = "terraform-%d-${count.index}"
   slug               = "terra-${count.index}"
   user_data_handling = "pass-through"

--- a/cloudscale/resource_cloudscale_custom_image.go
+++ b/cloudscale/resource_cloudscale_custom_image.go
@@ -94,8 +94,8 @@ func getCustomImageSchema(t SchemaType) map[string]*schema.Schema {
 		}
 		m["import_source_format"] = &schema.Schema{
 			Type:     schema.TypeString,
-			Required: true,
-			ForceNew: true,
+			Optional: true,
+			ForceNew: false,
 		}
 		m["import_uuid"] = &schema.Schema{
 			Type:     schema.TypeString,
@@ -124,22 +124,20 @@ func resourceCustomImageCreate(d *schema.ResourceData, meta any) error {
 		Name:             d.Get("name").(string),
 		Slug:             d.Get("slug").(string),
 		UserDataHandling: d.Get("user_data_handling").(string),
-		SourceFormat:     d.Get("import_source_format").(string),
-		Zones:            nil,
+		// import_source_format is intentionally ignored, as it is also ignored by the upstream api
+		Zones: nil,
 	}
 	opts.Tags = CopyTags(d)
 	zoneSlugs := d.Get("zone_slugs").(*schema.Set).List()
 	z := make([]string, len(zoneSlugs))
-
 	for i := range zoneSlugs {
 		z[i] = zoneSlugs[i].(string)
 	}
+	opts.Zones = z
 
 	if attr, ok := d.GetOk("firmware_type"); ok {
 		opts.FirmwareType = attr.(string)
 	}
-
-	opts.Zones = z
 
 	log.Printf("[DEBUG] CustomImage create configuration: %#v", opts)
 

--- a/cloudscale/resource_cloudscale_custom_image_test.go
+++ b/cloudscale/resource_cloudscale_custom_image_test.go
@@ -83,8 +83,6 @@ func TestAccCloudscaleCustomImage_Import(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"cloudscale_custom_image.basic", "slug", "terra-test-slug"),
 					resource.TestCheckResourceAttr(
-						"cloudscale_custom_image.basic", "import_source_format", "raw"),
-					resource.TestCheckResourceAttr(
 						"cloudscale_custom_image.basic", "import_url", smallImageDownloadURL),
 					resource.TestCheckResourceAttr(
 						"cloudscale_custom_image.basic", "user_data_handling", "extend-cloud-config"),
@@ -129,8 +127,6 @@ func TestAccCloudscaleCustomImage_Update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"cloudscale_custom_image.basic", "slug", "terra-test-slug"),
 					resource.TestCheckResourceAttr(
-						"cloudscale_custom_image.basic", "import_source_format", "raw"),
-					resource.TestCheckResourceAttr(
 						"cloudscale_custom_image.basic", "import_url", smallImageDownloadURL),
 					resource.TestCheckResourceAttr(
 						"cloudscale_custom_image.basic", "user_data_handling", "extend-cloud-config"),
@@ -158,8 +154,6 @@ func TestAccCloudscaleCustomImage_Update(t *testing.T) {
 						"cloudscale_custom_image.basic", "name", fmt.Sprintf("terraform-%d-renamed", rInt)),
 					resource.TestCheckResourceAttr(
 						"cloudscale_custom_image.basic", "slug", "terra-test-slug-changed"),
-					resource.TestCheckResourceAttr(
-						"cloudscale_custom_image.basic", "import_source_format", "raw"),
 					resource.TestCheckResourceAttr(
 						"cloudscale_custom_image.basic", "import_url", smallImageDownloadURL),
 					resource.TestCheckResourceAttr(
@@ -312,7 +306,6 @@ func customImageConfig_config(name string, imageDownloadURL string, rInt int) st
 	return fmt.Sprintf(`
 resource "cloudscale_custom_image" "%s" {
   import_url         = "%s"
-  import_source_format      = "raw"
   name               = "terraform-%d"
   slug               = "terra-test-slug"
   user_data_handling = "extend-cloud-config"
@@ -325,7 +318,6 @@ func customImageConfig_tags(name string, imageDownloadURL string, rInt int) stri
 	return fmt.Sprintf(`
 resource "cloudscale_custom_image" "%s" {
   import_url         = "%s"
-  import_source_format      = "raw"
   name               = "terraform-%d"
   slug               = "terra-test-slug"
   user_data_handling = "extend-cloud-config"
@@ -341,7 +333,6 @@ func customImageConfig_changed(name string, imageDownloadURL string, rInt int) s
 	return fmt.Sprintf(`
 resource "cloudscale_custom_image" "%s" {
   import_url         = "%s"
-  import_source_format      = "raw"
   name               = "terraform-%d-renamed"
   slug               = "terra-test-slug-changed"
   user_data_handling = "pass-through"

--- a/docs/resources/custom_image.md
+++ b/docs/resources/custom_image.md
@@ -12,7 +12,6 @@ Provides a cloudscale.ch custom image resource. This can be used to create, modi
 # Create a custom image
 resource "cloudscale_custom_image" "your_image" {
   import_url           = "https://mirror.example.com/your-distro-12.12-openstack-amd64.raw"
-  import_source_format = "raw"
   name                 = "Your Distro 12.12"
   slug                 = "your-distro-12.12"
   user_data_handling   = "extend-cloud-config"
@@ -50,7 +49,7 @@ resource "cloudscale_server" "your_server" {
 The following arguments are supported when creating/changing custom images:
 
 * `import_url` - (Required) The URL used to download the image.
-* `import_source_format` - (Required) The file format of the image referenced in the `import_url`. Options include `raw`.
+* `import_source_format` - (Optional, Ignored) Deprecated: this field no longer needs to be specified and will be ignored. The image format is detected automatically.
 * `name` - (Required) The human-readable name of the custom image.
 * `slug` - (Optional) A string identifying the custom image for use within the API.
 * `user_data_handling` - (Required) How user_data will be handled when creating a server. Options include `pass-through` and `extend-cloud-config`.


### PR DESCRIPTION
`import_source_format` is no longer used by the cloudscale.ch API. Ignore in the provider as well.