### PR TITLE
Use a more exact integration test name

### DIFF
--- a/.github/workflows/terraform-integration-tests.yml
+++ b/.github/workflows/terraform-integration-tests.yml
@@ -1,7 +1,7 @@
 # This GitHub action runs your tests for each commit push and/or PR. Optionally
 # you can turn it on using a cron schedule for regular testing.
 #
-name: Tests
+name: Terraform Integration Tests
 on:
   push:
     paths-ignore:


### PR DESCRIPTION
This enables the internal test monitoring to show more descriptive names.