### PR TITLE
Server Update Timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist/
 vendor
+terraform-provider-cloudscale

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 5.0.0
+* :warning: **Breaking Change**: The default value for the `status` attribute 
+  of `cloudscale_server` is now `"running"` when no value is provided 
+  (i.e., missing in your .tf file). If your servers are intended to be in
+  a state other than `"running"`, please explicitly set the appropriate state
+  before upgrading to this version.
+* :warning: **Breaking Change**: The default timeout for server changes is 
+  now `1h` instead of `5m`. This change is necessary because changing the 
+  flavor of a GPU server with a scratch disk can take a significant 
+  amount of time if data is moved to a new host during the process. 
+  If you prefer to use the old timeout, you can now add the following 
+  block to your `cloudscale_server` configuration:
+  ```hcl
+  timeouts {
+    update = "5m"
+  }
+* Update go dependencies.
+
 ## 4.4.0
 * Use `import_source_format` again. This must be specified to import custom images in formats other than `raw`. 
   See also [our blog](https://www.cloudscale.ch/en/news/2024/07/31/securing-qcow2-image-imports). 

--- a/README.md
+++ b/README.md
@@ -59,15 +59,7 @@ provider_installation {
 
 *Remember to replace `[your-username]` with your actual username.*
 
-### 3. Generate or Update Documentation
-
-Update the documentation by running:
-
-```sh
-go generate
-```
-
-### 4. Running Acceptance Tests
+### 3. Running Acceptance Tests
 
 Acceptance tests create real resources and might incur costs. They also use a specific version of Terraform (see [Terraform CLI Installation Behaviors](https://www.terraform.io/plugin/sdkv2/testing/acceptance-tests#terraform-cli-installation-behaviors)).
 
@@ -83,7 +75,7 @@ Acceptance tests create real resources and might incur costs. They also use a sp
   TESTARGS="-run TestAccCloudscaleSubnet" make testacc
   ```
 
-### 5. Upgrading the cloudscale-go-sdk
+### 4. Upgrading the cloudscale-go-sdk
 
 - **Upgrade to the latest version:**
 
@@ -92,7 +84,7 @@ Acceptance tests create real resources and might incur costs. They also use a sp
   go mod tidy
   ```
 
-### 6. Working with Different Versions of the cloudscale-go-sdk
+### 5. Working with Different Versions of the cloudscale-go-sdk
 
 If you want to work with a local version or a specific version of the cloudscale-go-sdk during development, use the
 following commands:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,31 @@ To create builds for different platforms, you can use [goreleaser](https://gorel
   docker run -it --rm -v $PWD:/app --workdir=/app goreleaser/goreleaser:v2.1.0 release --snapshot --clean --skip=publish,sign
   ```
 
-### 2. Generate or Update Documentation
+### 2. Testing Unreleased Driver Versions
+
+To test unreleased driver versions, add the following to your `~/.terraformrc` file.
+This configuration directs Terraform to use your local `go/bin` directory for the cloudscale provider:
+
+```hcl
+provider_installation {
+  # Use go/bin as an overridden package directory
+  # for the cloudscale-ch/cloudscale provider. This disables the version and checksum
+  # verifications for this provider and forces Terraform to look for the
+  # null provider plugin in the given directory.
+  dev_overrides {
+    "cloudscale-ch/cloudscale" = "/Users/[your-username]/go/bin"
+  }
+
+  # For all other providers, install them directly from their origin provider
+  # registries as normal. If you omit this, Terraform will _only_ use
+  # the dev_overrides block, and so no other providers will be available.
+  direct {}
+}
+```
+
+*Remember to replace `[your-username]` with your actual username.*
+
+### 3. Generate or Update Documentation
 
 Update the documentation by running:
 
@@ -43,7 +67,7 @@ Update the documentation by running:
 go generate
 ```
 
-### 3. Running Acceptance Tests
+### 4. Running Acceptance Tests
 
 Acceptance tests create real resources and might incur costs. They also use a specific version of Terraform (see [Terraform CLI Installation Behaviors](https://www.terraform.io/plugin/sdkv2/testing/acceptance-tests#terraform-cli-installation-behaviors)).
 
@@ -59,7 +83,7 @@ Acceptance tests create real resources and might incur costs. They also use a sp
   TESTARGS="-run TestAccCloudscaleSubnet" make testacc
   ```
 
-### 4. Upgrading the cloudscale-go-sdk
+### 5. Upgrading the cloudscale-go-sdk
 
 - **Upgrade to the latest version:**
 
@@ -68,7 +92,7 @@ Acceptance tests create real resources and might incur costs. They also use a sp
   go mod tidy
   ```
 
-### 5. Working with Different Versions of the cloudscale-go-sdk
+### 6. Working with Different Versions of the cloudscale-go-sdk
 
 If you want to work with a local version or a specific version of the cloudscale-go-sdk during development, use the
 following commands:
@@ -96,39 +120,14 @@ following commands:
   go mod tidy
   ```
 
-### 6. Testing Unreleased Driver Versions
-
-To test unreleased driver versions, add the following to your `~/.terraformrc` file.
-This configuration directs Terraform to use your local `go/bin` directory for the cloudscale provider:
-
-```hcl
-provider_installation {
-  # Use go/bin as an overridden package directory
-  # for the cloudscale-ch/cloudscale provider. This disables the version and checksum
-  # verifications for this provider and forces Terraform to look for the
-  # null provider plugin in the given directory.
-  dev_overrides {
-    "cloudscale-ch/cloudscale" = "/Users/[your-username]/go/bin"
-  }
-
-  # For all other providers, install them directly from their origin provider
-  # registries as normal. If you omit this, Terraform will _only_ use
-  # the dev_overrides block, and so no other providers will be available.
-  direct {}
-}
-```
-
-*Remember to replace `[your-username]` with your actual username.*
-
-
 ## Releasing the Provider
 
 1. Ensure the `CHANGELOG.md` is up-to-date.
-2. Ensure the `.github/workflows/terraform-integration-tests.yml` tests the 3 most recent Terraform versions.
-3. Create a new release [on GitHub](https://github.com/cloudscale-ch/terraform-provider-cloudscale/releases/new).
+1. Ensure the `.github/workflows/terraform-integration-tests.yml` tests the 3 most recent Terraform versions.
+1. Create a new release [on GitHub](https://github.com/cloudscale-ch/terraform-provider-cloudscale/releases/new).
    Both the tag and release title must follow this pattern: `v<<SEMVER>>`.
    Examples: `v42.43.44` or `v1.33.7-rc.1`.
-4. It might take a moment until the release appears in the [Terraform registry](https://registry.terraform.io/providers/cloudscale-ch/cloudscale/latest).
+1. It might take a moment until the release appears in the [Terraform registry](https://registry.terraform.io/providers/cloudscale-ch/cloudscale/latest).
    You can manually resync the provider when you are logged in to the registry.
 
 ## Developing the Documentation Website

--- a/README.md
+++ b/README.md
@@ -1,18 +1,15 @@
-cloudscale.ch Terraform Provider
-==================
+# cloudscale.ch Terraform Provider
 
 - Website: https://www.terraform.io
 - [![Gitter chat](https://badges.gitter.im/hashicorp-terraform/Lobby.png)](https://gitter.im/hashicorp-terraform/Lobby)
 - Mailing list: [Google Groups](http://groups.google.com/group/terraform-tool)
 
-Requirements
-------------
+## Requirements
 
--	[Terraform](https://www.terraform.io/downloads.html) 0.12 or higher
--	[Go](https://golang.org/doc/install) to build the provider plugin
+- [Terraform](https://www.terraform.io/downloads.html) 0.12 or higher
+- [Go](https://golang.org/doc/install) to build the provider plugin
 
-Developing the Provider
----------------------------
+## Developing the Provider
 
 If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (see [Requirements](#requirements) above).
 
@@ -22,10 +19,11 @@ To generate or update documentation, run `go generate`.
 
 In order to run the full suite of Acceptance tests, run `make testacc`.
 
-*Notes:* 
- * Acceptance tests create real resources, and often cost money to run.
- * [See here](https://www.terraform.io/plugin/sdkv2/testing/acceptance-tests#terraform-cli-installation-behaviors)
-   to understand which version of Terraform is used in your tests.
+*Notes:*
+
+- Acceptance tests create real resources, and often cost money to run.
+- [See here](https://www.terraform.io/plugin/sdkv2/testing/acceptance-tests#terraform-cli-installation-behaviors)
+  to understand which version of Terraform is used in your tests.
 
 ```sh
 $ make testacc
@@ -33,7 +31,7 @@ $ make testacc
 
 To run a subset of the tests:
 
-``` sh
+```sh
 $ TESTARGS="-run TestAccCloudscaleSubnet" make testacc
 ```
 
@@ -44,8 +42,8 @@ go get -u github.com/cloudscale-ch/cloudscale-go-sdk/v5
 go mod tidy
 ```
 
-
 Use the following commands to switch to a local version of the go-sdk:
+
 ```sh
 go mod edit -replace "github.com/cloudscale-ch/cloudscale-go-sdk/v4=../cloudscale-go-sdk/"
 go mod tidy
@@ -53,13 +51,15 @@ git commit -m "drop: Use local version of cloudscale-go-sdk"
 ```
 
 Or use the following command to pin to a specific commit from GitHub:
+
 ```sh
 go mod edit -replace "github.com/cloudscale-ch/cloudscale-go-sdk/v4=github.com/cloudscale-ch/cloudscale-go-sdk/v4@<commit-hash>"
 go mod tidy
 git commit -m "drop: Pin specific commit of cloudscale-go-sdk"
 ```
 
-And finally, to switch back: 
+And finally, to switch back:
+
 ```sh
 go mod edit -dropreplace "github.com/cloudscale-ch/cloudscale-go-sdk/v4"
 go mod tidy
@@ -93,19 +93,16 @@ docker run -it --rm -v $PWD:/app --workdir=/app goreleaser/goreleaser:v1.26.2 re
 docker run -it --rm -v $PWD:/app --workdir=/app goreleaser/goreleaser:v2.1.0 release --snapshot --clean --skip=publish,sign
 ```
 
-Releasing the Provider
----------------------------
+## Releasing the Provider
 
- 1. Ensure the `CHANGELOG.md` is up-to-date.
- 2. Ensure the `.github/workflows/terraform-integration-tests.yml` tests the 3 most recent Terraform versions.
- 3. Create a new release [on GitHub](https://github.com/cloudscale-ch/terraform-provider-cloudscale/releases/new).
-    Both the tag and release title must follow this pattern: `v<<SEMVER>>`.
-    Examples: `v42.43.44` or `v1.33.7-rc.1`.
- 4. It might take a moment until the release appears in the [Terraform registry](https://registry.terraform.io/providers/cloudscale-ch/cloudscale/latest).
-    You can manually resync the provider when you are logged in to the registry. 
+1. Ensure the `CHANGELOG.md` is up-to-date.
+2. Ensure the `.github/workflows/terraform-integration-tests.yml` tests the 3 most recent Terraform versions.
+3. Create a new release [on GitHub](https://github.com/cloudscale-ch/terraform-provider-cloudscale/releases/new).
+   Both the tag and release title must follow this pattern: `v<<SEMVER>>`.
+   Examples: `v42.43.44` or `v1.33.7-rc.1`.
+4. It might take a moment until the release appears in the [Terraform registry](https://registry.terraform.io/providers/cloudscale-ch/cloudscale/latest).
+   You can manually resync the provider when you are logged in to the registry.
 
-
-Developing the Documentation Website
-------------------------------------
+## Developing the Documentation Website
 
 Use the Terraform [doc preview tool](https://registry.terraform.io/tools/doc-preview) to test markdown rendering.

--- a/README.md
+++ b/README.md
@@ -35,12 +35,13 @@ To create builds for different platforms, you can use [goreleaser](https://gorel
   docker run -it --rm -v $PWD:/app --workdir=/app goreleaser/goreleaser:v2.1.0 release --snapshot --clean --skip=publish,sign
   ```
 
-### 2. Testing Unreleased Driver Versions
+### 2. Testing Locally Compiled Driver
 
-To test unreleased driver versions, add the following to your `~/.terraformrc` file.
+To test a locally compiled driver, add the following to your `~/.terraformrc` file.
 This configuration directs Terraform to use your local `go/bin` directory for the cloudscale provider:
 
 ```hcl
+# Contents of ~/.terraformrc
 provider_installation {
   # Use go/bin as an overridden package directory
   # for the cloudscale-ch/cloudscale provider. This disables the version and checksum

--- a/README.md
+++ b/README.md
@@ -4,68 +4,102 @@
 - [![Gitter chat](https://badges.gitter.im/hashicorp-terraform/Lobby.png)](https://gitter.im/hashicorp-terraform/Lobby)
 - Mailing list: [Google Groups](http://groups.google.com/group/terraform-tool)
 
-## Requirements
+## Using the Provider
 
-- [Terraform](https://www.terraform.io/downloads.html) 0.12 or higher
-- [Go](https://golang.org/doc/install) to build the provider plugin
+For detailed usage instructions and examples, please refer to the official documentation available
+at [Terraform Registry: cloudscale-ch/cloudscale](https://registry.terraform.io/providers/cloudscale-ch/cloudscale/latest).
 
 ## Developing the Provider
 
-If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (see [Requirements](#requirements) above).
+Before you begin, make sure you have [Go](http://golang.org) installed on your machine.
 
-To compile the provider, run `go install`. This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
+### 1. Compile the Provider
 
-To generate or update documentation, run `go generate`.
-
-In order to run the full suite of Acceptance tests, run `make testacc`.
-
-*Notes:*
-
-- Acceptance tests create real resources, and often cost money to run.
-- [See here](https://www.terraform.io/plugin/sdkv2/testing/acceptance-tests#terraform-cli-installation-behaviors)
-  to understand which version of Terraform is used in your tests.
+Run the following command to compile the provider. The binary will be placed in your `$GOPATH/bin` directory.
 
 ```sh
-$ make testacc
+go install
 ```
 
-To run a subset of the tests:
+To create builds for different platforms, you can use [goreleaser](https://goreleaser.com/):
+
+- **For goreleaser v1.x:**
+
+  ```sh
+  docker run -it --rm -v $PWD:/app --workdir=/app goreleaser/goreleaser:v1.26.2 release --snapshot --rm-dist --skip-sign
+  ```
+
+- **For goreleaser v2.x:**
+
+  ```sh
+  docker run -it --rm -v $PWD:/app --workdir=/app goreleaser/goreleaser:v2.1.0 release --snapshot --clean --skip=publish,sign
+  ```
+
+### 2. Generate or Update Documentation
+
+Update the documentation by running:
 
 ```sh
-$ TESTARGS="-run TestAccCloudscaleSubnet" make testacc
+go generate
 ```
 
-In order to upgrade the `cloudscale-go-sdk`.
+### 3. Running Acceptance Tests
 
-```sh
-go get -u github.com/cloudscale-ch/cloudscale-go-sdk/v5
-go mod tidy
-```
+Acceptance tests create real resources and might incur costs. They also use a specific version of Terraform (see [Terraform CLI Installation Behaviors](https://www.terraform.io/plugin/sdkv2/testing/acceptance-tests#terraform-cli-installation-behaviors)).
 
-Use the following commands to switch to a local version of the go-sdk:
+- **Run all tests:**
 
-```sh
-go mod edit -replace "github.com/cloudscale-ch/cloudscale-go-sdk/v4=../cloudscale-go-sdk/"
-go mod tidy
-git commit -m "drop: Use local version of cloudscale-go-sdk"
-```
+  ```sh
+  make testacc
+  ```
 
-Or use the following command to pin to a specific commit from GitHub:
+- **Run a subset of the tests (e.g., tests for subnet):**
 
-```sh
-go mod edit -replace "github.com/cloudscale-ch/cloudscale-go-sdk/v4=github.com/cloudscale-ch/cloudscale-go-sdk/v4@<commit-hash>"
-go mod tidy
-git commit -m "drop: Pin specific commit of cloudscale-go-sdk"
-```
+  ```sh
+  TESTARGS="-run TestAccCloudscaleSubnet" make testacc
+  ```
 
-And finally, to switch back:
+### 4. Upgrading the cloudscale-go-sdk
 
-```sh
-go mod edit -dropreplace "github.com/cloudscale-ch/cloudscale-go-sdk/v4"
-go mod tidy
-```
+- **Upgrade to the latest version:**
 
-To test unreleased driver versions, locally add the following to your `~/.terraformrc`
+  ```sh
+  go get -u github.com/cloudscale-ch/cloudscale-go-sdk/v5
+  go mod tidy
+  ```
+
+### 5. Working with Different Versions of the cloudscale-go-sdk
+
+If you want to work with a local version or a specific version of the cloudscale-go-sdk during development, use the
+following commands:
+
+- **Replace with a local version:**
+
+  ```sh
+  go mod edit -replace "github.com/cloudscale-ch/cloudscale-go-sdk/v4=../cloudscale-go-sdk/"
+  go mod tidy
+  git commit -m "drop: Use local version of cloudscale-go-sdk"
+  ```
+
+- **Pin to a specific commit:**
+
+  ```sh
+  go mod edit -replace "github.com/cloudscale-ch/cloudscale-go-sdk/v4=github.com/cloudscale-ch/cloudscale-go-sdk/v4@<commit-hash>"
+  go mod tidy
+  git commit -m "drop: Pin specific commit of cloudscale-go-sdk"
+  ```
+
+- **Switch back to the upstream version:**
+
+  ```sh
+  go mod edit -dropreplace "github.com/cloudscale-ch/cloudscale-go-sdk/v4"
+  go mod tidy
+  ```
+
+### 6. Testing Unreleased Driver Versions
+
+To test unreleased driver versions, add the following to your `~/.terraformrc` file.
+This configuration directs Terraform to use your local `go/bin` directory for the cloudscale provider:
 
 ```hcl
 provider_installation {
@@ -74,7 +108,7 @@ provider_installation {
   # verifications for this provider and forces Terraform to look for the
   # null provider plugin in the given directory.
   dev_overrides {
-    "cloudscale-ch/cloudscale" = "/Users/alain/go/bin"
+    "cloudscale-ch/cloudscale" = "/Users/[your-username]/go/bin"
   }
 
   # For all other providers, install them directly from their origin provider
@@ -84,14 +118,8 @@ provider_installation {
 }
 ```
 
-To cross-compile a local build, run:
+*Remember to replace `[your-username]` with your actual username.*
 
-```
-# goreleaser v1.x
-docker run -it --rm -v $PWD:/app --workdir=/app goreleaser/goreleaser:v1.26.2 release --snapshot --rm-dist --skip-sign
-# goreleaser v2.x
-docker run -it --rm -v $PWD:/app --workdir=/app goreleaser/goreleaser:v2.1.0 release --snapshot --clean --skip=publish,sign
-```
 
 ## Releasing the Provider
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ at [Terraform Registry: cloudscale-ch/cloudscale](https://registry.terraform.io/
 
 Before you begin, make sure you have [Go](http://golang.org) installed on your machine.
 
-### 1. Compile the Provider
+### Compile the Provider
 
 Run the following command to compile the provider. The binary will be placed in your `$GOPATH/bin` directory.
 
@@ -35,7 +35,7 @@ To create builds for different platforms, you can use [goreleaser](https://gorel
   docker run -it --rm -v $PWD:/app --workdir=/app goreleaser/goreleaser:v2.1.0 release --snapshot --clean --skip=publish,sign
   ```
 
-### 2. Testing Locally Compiled Driver
+### Testing Locally Compiled Driver
 
 To test a locally compiled driver, add the following to your `~/.terraformrc` file.
 This configuration directs Terraform to use your local `go/bin` directory for the cloudscale provider:
@@ -60,7 +60,7 @@ provider_installation {
 
 *Remember to replace `[your-username]` with your actual username.*
 
-### 3. Running Acceptance Tests
+### Running Acceptance Tests
 
 Acceptance tests create real resources and might incur costs. They also use a specific version of Terraform (see [Terraform CLI Installation Behaviors](https://www.terraform.io/plugin/sdkv2/testing/acceptance-tests#terraform-cli-installation-behaviors)).
 
@@ -76,7 +76,7 @@ Acceptance tests create real resources and might incur costs. They also use a sp
   TESTARGS="-run TestAccCloudscaleSubnet" make testacc
   ```
 
-### 4. Upgrading the cloudscale-go-sdk
+### Upgrading the cloudscale-go-sdk
 
 - **Upgrade to the latest version:**
 
@@ -85,7 +85,7 @@ Acceptance tests create real resources and might incur costs. They also use a sp
   go mod tidy
   ```
 
-### 5. Working with Different Versions of the cloudscale-go-sdk
+### Working with Different Versions of the cloudscale-go-sdk
 
 If you want to work with a local version or a specific version of the cloudscale-go-sdk during development, use the
 following commands:

--- a/cloudscale/datasource_cloudscale_server_test.go
+++ b/cloudscale/datasource_cloudscale_server_test.go
@@ -36,6 +36,8 @@ func TestAccCloudscaleServer_DS_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.cloudscale_server.foo", "name", name1),
 					resource.TestCheckResourceAttr(
+						"data.cloudscale_server.foo", "status", "running"),
+					resource.TestCheckResourceAttr(
 						"data.cloudscale_server.foo", "flavor_slug", "flex-4-1"),
 					resource.TestCheckResourceAttr(
 						"data.cloudscale_server.foo", "image_slug", DefaultImageSlug),

--- a/cloudscale/resource_cloudscale_server.go
+++ b/cloudscale/resource_cloudscale_server.go
@@ -188,7 +188,7 @@ func getServerSchema(t SchemaType) map[string]*schema.Schema {
 		},
 		"status": {
 			Type:     schema.TypeString,
-			Default:  "running",
+			Default:  cloudscale.ServerRunning,
 			Optional: true,
 		},
 		"tags": &TagsSchema,

--- a/cloudscale/resource_cloudscale_server.go
+++ b/cloudscale/resource_cloudscale_server.go
@@ -26,7 +26,7 @@ func resourceCloudscaleServer() *schema.Resource {
 		Schema: getServerSchema(RESOURCE),
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(5 * time.Minute),
-			Update: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(1 * time.Hour),
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceCloudscaleServerImport,

--- a/cloudscale/resource_cloudscale_server.go
+++ b/cloudscale/resource_cloudscale_server.go
@@ -188,8 +188,8 @@ func getServerSchema(t SchemaType) map[string]*schema.Schema {
 		},
 		"status": {
 			Type:     schema.TypeString,
-			Optional: t.isResource(),
-			Computed: true,
+			Default:  "running",
+			Optional: true,
 		},
 		"tags": &TagsSchema,
 		"server_groups": {

--- a/cloudscale/resource_cloudscale_server_test.go
+++ b/cloudscale/resource_cloudscale_server_test.go
@@ -162,6 +162,8 @@ func TestAccCloudscaleServer_UpdateStatus(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"cloudscale_server.basic", "name", fmt.Sprintf("terraform-%d", rInt)),
 					resource.TestCheckResourceAttr(
+						"cloudscale_server.basic", "status", "running"),
+					resource.TestCheckResourceAttr(
 						"cloudscale_server.basic", "flavor_slug", "flex-4-1"),
 					resource.TestCheckResourceAttr(
 						"cloudscale_server.basic", "image_slug", DefaultImageSlug),

--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -19,7 +19,7 @@ resource "cloudscale_server" "web-worker01" {
   
   timeouts {
     create = "10m"
-    update = "30m"
+    update = "1h"
   }
 }
 ```
@@ -54,8 +54,8 @@ The following arguments are supported when creating new servers:
 * `allow_stopping_for_update` - (Optional) If true, allows Terraform to stop the instance to update its properties. If you try to update a property that requires stopping the instance without setting this field, the update will fail.
 * `skip_waiting_for_ssh_host_keys` - (Optional) If set to `true`, do not wait until SSH host keys become available.
 * `timeouts` - (Optional) Specify how long certain operations are allowed to take before being considered to have failed. The following timeouts can be specified:
-    - `create` - The timeout for creating a resource. Takes a string representation of a duration such as `5m` for 5 minutes (default), `10s` for ten seconds, or `2h` for two hours. The default value is `5m`.
-    - `update` - The timeout for updating a resource. Takes a string representation of a duration such as `5m` for 5 minutes (default), `10s` for ten seconds, or `2h` for two hours. The default value is `5m`.
+    - `create` - The timeout for creating a resource. Takes a string representation of a duration such as `5m` for 5 minutes, `10s` for ten seconds, or `2h` for two hours. The default value is `5m`.
+    - `update` - The timeout for updating a resource. Takes a string representation of a duration such as `5m` for 5 minutes, `10s` for ten seconds, or `2h` for two hours. The default value is `1h`.
 * `tags` - (Optional) Tags allow you to assign custom metadata to resources:
   ```
   tags = {

--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -19,6 +19,7 @@ resource "cloudscale_server" "web-worker01" {
   
   timeouts {
     create = "10m"
+    update = "30m"
   }
 }
 ```
@@ -52,7 +53,9 @@ The following arguments are supported when creating new servers:
 * `status` - (Optional) The desired state of a server. Can be `running` (default) or `stopped`.
 * `allow_stopping_for_update` - (Optional) If true, allows Terraform to stop the instance to update its properties. If you try to update a property that requires stopping the instance without setting this field, the update will fail.
 * `skip_waiting_for_ssh_host_keys` - (Optional) If set to `true`, do not wait until SSH host keys become available.
-* `timeouts` - (Optional) Specify how long certain operations are allowed to take before being considered to have failed. Currently, only the `create` timeout can be specified. Takes a string representation of a duration such as `5m` for 5 minutes (default), `10s` for ten seconds, or `2h` for two hours.
+* `timeouts` - (Optional) Specify how long certain operations are allowed to take before being considered to have failed. The following timeouts can be specified:
+    - `create` - The timeout for creating a resource. Takes a string representation of a duration such as `5m` for 5 minutes (default), `10s` for ten seconds, or `2h` for two hours. The default value is `5m`.
+    - `update` - The timeout for updating a resource. Takes a string representation of a duration such as `5m` for 5 minutes (default), `10s` for ten seconds, or `2h` for two hours. The default value is `5m`.
 * `tags` - (Optional) Tags allow you to assign custom metadata to resources:
   ```
   tags = {


### PR DESCRIPTION
Add timeout parameter to the server update operation.

Updating the flavor of a GPU server, can take several minutes under some circumstances.