### PR TITLE
fix: make TF delete calls more resilient

### DIFF
--- a/.github/workflows/terraform-integration-tests.yml
+++ b/.github/workflows/terraform-integration-tests.yml
@@ -90,4 +90,4 @@ jobs:
       if: env.CLOUDSCALE_API_TOKEN != null
 
       run: |
-        go test ./... -v $TESTARGS -timeout 120m
+        go test ./... -v $TESTARGS -parallel 2 -timeout 120m

--- a/cloudscale/resource_cloudscale_network.go
+++ b/cloudscale/resource_cloudscale_network.go
@@ -2,8 +2,11 @@ package cloudscale
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
+	"net/http"
+	"time"
 
 	"github.com/cloudscale-ch/cloudscale-go-sdk/v9"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -28,6 +31,9 @@ func resourceCloudscaleNetwork() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Schema: getNetworkSchema(RESOURCE),
+		Timeouts: &schema.ResourceTimeout{
+			Delete: schema.DefaultTimeout(3 * time.Minute),
+		},
 	}
 }
 
@@ -182,5 +188,26 @@ func gatherNetworkUpdateRequest(d *schema.ResourceData) []*cloudscale.NetworkUpd
 func deleteNetwork(d *schema.ResourceData, meta any) error {
 	client := meta.(*cloudscale.Client)
 	id := d.Id()
-	return client.Networks.Delete(context.Background(), id)
+	if err := client.Networks.Delete(context.Background(), id); err != nil {
+		return err
+	}
+	return waitForNetworkDeleted(id, meta, d.Timeout(schema.TimeoutDelete))
+}
+
+func waitForNetworkDeleted(id string, meta any, remaining time.Duration) error {
+	client := meta.(*cloudscale.Client)
+	err := waitForDeleted(remaining, func() (exists bool, err error) {
+		_, err = client.Networks.Get(context.Background(), id)
+		if err != nil {
+			if errorResponse, ok := errors.AsType[*cloudscale.ErrorResponse](err); ok && errorResponse.StatusCode == http.StatusNotFound {
+				return false, nil
+			}
+			return false, fmt.Errorf("error retrieving network (%s) (delete refresh) %s", id, err)
+		}
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("error waiting for network (%s) to be deleted: %s", id, err)
+	}
+	return nil
 }

--- a/cloudscale/resource_cloudscale_server.go
+++ b/cloudscale/resource_cloudscale_server.go
@@ -2,8 +2,10 @@ package cloudscale
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/cloudscale-ch/cloudscale-go-sdk/v9"
@@ -27,6 +29,7 @@ func resourceCloudscaleServer() *schema.Resource {
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(5 * time.Minute),
 			Update: schema.DefaultTimeout(1 * time.Hour),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceCloudscaleServerImport,
@@ -678,7 +681,34 @@ func resourceCloudscaleServerUpdate(d *schema.ResourceData, meta any) error {
 func deleteServer(d *schema.ResourceData, meta any) error {
 	client := meta.(*cloudscale.Client)
 	id := d.Id()
-	return client.Servers.Delete(context.Background(), id)
+	if err := client.Servers.Delete(context.Background(), id); err != nil {
+		return err
+	}
+	if err := waitForServerDeleted(id, meta, d.Timeout(schema.TimeoutDelete)); err != nil {
+		return err
+	}
+	// Brief grace period after the server record disappears
+	time.Sleep(5 * time.Second)
+	return nil
+}
+
+func waitForServerDeleted(id string, meta any, remaining time.Duration) error {
+	client := meta.(*cloudscale.Client)
+	err := waitForDeleted(remaining, func() (exists bool, err error) {
+		server, err := client.Servers.Get(context.Background(), id)
+		if err != nil {
+			if errorResponse, ok := errors.AsType[*cloudscale.ErrorResponse](err); ok && errorResponse.StatusCode == http.StatusNotFound {
+				return false, nil
+			}
+			return false, fmt.Errorf("error retrieving server (%s) (delete refresh) %s", id, err)
+		}
+		log.Printf("[INFO] Status is %s", server.Status)
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("error waiting for server (%s) to be deleted: %s", id, err)
+	}
+	return nil
 }
 
 func newServerRefreshFunc(d *schema.ResourceData, attribute string, meta any) resource.StateRefreshFunc {

--- a/cloudscale/resource_cloudscale_subnet.go
+++ b/cloudscale/resource_cloudscale_subnet.go
@@ -2,8 +2,10 @@ package cloudscale
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/cloudscale-ch/cloudscale-go-sdk/v9"
@@ -29,6 +31,9 @@ func resourceCloudscaleSubnet() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Schema: getSubnetSchema(RESOURCE),
+		Timeouts: &schema.ResourceTimeout{
+			Delete: schema.DefaultTimeout(3 * time.Minute),
+		},
 	}
 }
 
@@ -200,7 +205,26 @@ func gatherSubnetUpdateRequests(d *schema.ResourceData) []*cloudscale.SubnetUpda
 func deleteSubnet(d *schema.ResourceData, meta any) error {
 	client := meta.(*cloudscale.Client)
 	id := d.Id()
-	// sending the next request immediately can cause errors, since the port cleanup process is still ongoing
-	time.Sleep(5 * time.Second)
-	return client.Subnets.Delete(context.Background(), id)
+	if err := client.Subnets.Delete(context.Background(), id); err != nil {
+		return err
+	}
+	return waitForSubnetDeleted(id, meta, d.Timeout(schema.TimeoutDelete))
+}
+
+func waitForSubnetDeleted(id string, meta any, remaining time.Duration) error {
+	client := meta.(*cloudscale.Client)
+	err := waitForDeleted(remaining, func() (exists bool, err error) {
+		_, err = client.Subnets.Get(context.Background(), id)
+		if err != nil {
+			if errorResponse, ok := errors.AsType[*cloudscale.ErrorResponse](err); ok && errorResponse.StatusCode == http.StatusNotFound {
+				return false, nil
+			}
+			return false, fmt.Errorf("error retrieving subnet (%s) (delete refresh) %s", id, err)
+		}
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("error waiting for subnet (%s) to be deleted: %s", id, err)
+	}
+	return nil
 }


### PR DESCRIPTION
verify resource has been deleted within a given timeout, and for servers make sure to wait 5s after deletion to ensure everything is fully cleaned up