### PR TITLE
Serialize Concurrent Load Balancer Resource Operations Using a Mutex

### DIFF
--- a/cloudscale/datasource_cloudscale_custom_image.go
+++ b/cloudscale/datasource_cloudscale_custom_image.go
@@ -19,7 +19,7 @@ func dataSourceCloudscaleCustomImage() *schema.Resource {
 	}
 }
 
-func listCustomImages(d *schema.ResourceData, meta any) ([]cloudscale.CustomImage, error) {
+func listCustomImages(ctx context.Context, d *schema.ResourceData, meta any) ([]cloudscale.CustomImage, error) {
 	client := meta.(*cloudscale.Client)
-	return client.CustomImages.List(context.Background())
+	return client.CustomImages.List(ctx)
 }

--- a/cloudscale/datasource_cloudscale_floating_ip.go
+++ b/cloudscale/datasource_cloudscale_floating_ip.go
@@ -19,7 +19,7 @@ func dataSourceCloudscaleFloatingIP() *schema.Resource {
 	}
 }
 
-func listFloatingIPs(d *schema.ResourceData, meta any) ([]cloudscale.FloatingIP, error) {
+func listFloatingIPs(ctx context.Context, d *schema.ResourceData, meta any) ([]cloudscale.FloatingIP, error) {
 	client := meta.(*cloudscale.Client)
-	return client.FloatingIPs.List(context.Background())
+	return client.FloatingIPs.List(ctx)
 }

--- a/cloudscale/datasource_cloudscale_load_balancer.go
+++ b/cloudscale/datasource_cloudscale_load_balancer.go
@@ -18,7 +18,7 @@ func dataSourceCloudscaleLoadBalancer() *schema.Resource {
 	}
 }
 
-func listLoadBalancers(d *schema.ResourceData, meta any) ([]cloudscale.LoadBalancer, error) {
+func listLoadBalancers(ctx context.Context, d *schema.ResourceData, meta any) ([]cloudscale.LoadBalancer, error) {
 	client := meta.(*cloudscale.Client)
-	return client.LoadBalancers.List(context.Background())
+	return client.LoadBalancers.List(ctx)
 }

--- a/cloudscale/datasource_cloudscale_load_balancer_health_monitor.go
+++ b/cloudscale/datasource_cloudscale_load_balancer_health_monitor.go
@@ -18,7 +18,7 @@ func dataSourceCloudscaleLoadBalancerHealthMonitor() *schema.Resource {
 	}
 }
 
-func listLoadBalancerHealthMonitors(d *schema.ResourceData, meta any) ([]cloudscale.LoadBalancerHealthMonitor, error) {
+func listLoadBalancerHealthMonitors(ctx context.Context, d *schema.ResourceData, meta any) ([]cloudscale.LoadBalancerHealthMonitor, error) {
 	client := meta.(*cloudscale.Client)
-	return client.LoadBalancerHealthMonitors.List(context.Background())
+	return client.LoadBalancerHealthMonitors.List(ctx)
 }

--- a/cloudscale/datasource_cloudscale_load_balancer_listener.go
+++ b/cloudscale/datasource_cloudscale_load_balancer_listener.go
@@ -18,7 +18,7 @@ func dataSourceCloudscaleLoadBalancerListener() *schema.Resource {
 	}
 }
 
-func listLoadBalancerListeners(d *schema.ResourceData, meta any) ([]cloudscale.LoadBalancerListener, error) {
+func listLoadBalancerListeners(ctx context.Context, d *schema.ResourceData, meta any) ([]cloudscale.LoadBalancerListener, error) {
 	client := meta.(*cloudscale.Client)
-	return client.LoadBalancerListeners.List(context.Background())
+	return client.LoadBalancerListeners.List(ctx)
 }

--- a/cloudscale/datasource_cloudscale_load_balancer_pool.go
+++ b/cloudscale/datasource_cloudscale_load_balancer_pool.go
@@ -18,7 +18,7 @@ func dataSourceCloudscaleLoadBalancerPool() *schema.Resource {
 	}
 }
 
-func listLoadBalancerPools(d *schema.ResourceData, meta any) ([]cloudscale.LoadBalancerPool, error) {
+func listLoadBalancerPools(ctx context.Context, d *schema.ResourceData, meta any) ([]cloudscale.LoadBalancerPool, error) {
 	client := meta.(*cloudscale.Client)
-	return client.LoadBalancerPools.List(context.Background())
+	return client.LoadBalancerPools.List(ctx)
 }

--- a/cloudscale/datasource_cloudscale_load_balancer_pool_member.go
+++ b/cloudscale/datasource_cloudscale_load_balancer_pool_member.go
@@ -18,8 +18,8 @@ func dataSourceCloudscaleLoadBalancerPoolMember() *schema.Resource {
 	}
 }
 
-func listLoadBalancerPoolMembers(d *schema.ResourceData, meta any) ([]cloudscale.LoadBalancerPoolMember, error) {
+func listLoadBalancerPoolMembers(ctx context.Context, d *schema.ResourceData, meta any) ([]cloudscale.LoadBalancerPoolMember, error) {
 	client := meta.(*cloudscale.Client)
 	poolId := d.Get("pool_uuid").(string)
-	return client.LoadBalancerPoolMembers.List(context.Background(), poolId)
+	return client.LoadBalancerPoolMembers.List(ctx, poolId)
 }

--- a/cloudscale/datasource_cloudscale_network.go
+++ b/cloudscale/datasource_cloudscale_network.go
@@ -19,7 +19,7 @@ func dataSourceCloudscaleNetwork() *schema.Resource {
 	}
 }
 
-func listNetworks(d *schema.ResourceData, meta any) ([]cloudscale.Network, error) {
+func listNetworks(ctx context.Context, d *schema.ResourceData, meta any) ([]cloudscale.Network, error) {
 	client := meta.(*cloudscale.Client)
-	return client.Networks.List(context.Background())
+	return client.Networks.List(ctx)
 }

--- a/cloudscale/datasource_cloudscale_objects_user.go
+++ b/cloudscale/datasource_cloudscale_objects_user.go
@@ -19,7 +19,7 @@ func dataSourceCloudscaleObjectsUser() *schema.Resource {
 	}
 }
 
-func listObjectsUsers(d *schema.ResourceData, meta any) ([]cloudscale.ObjectsUser, error) {
+func listObjectsUsers(ctx context.Context, d *schema.ResourceData, meta any) ([]cloudscale.ObjectsUser, error) {
 	client := meta.(*cloudscale.Client)
-	return client.ObjectsUsers.List(context.Background())
+	return client.ObjectsUsers.List(ctx)
 }

--- a/cloudscale/datasource_cloudscale_server.go
+++ b/cloudscale/datasource_cloudscale_server.go
@@ -19,7 +19,7 @@ func dataSourceCloudscaleServer() *schema.Resource {
 	}
 }
 
-func listServers(d *schema.ResourceData, meta any) ([]cloudscale.Server, error) {
+func listServers(ctx context.Context, d *schema.ResourceData, meta any) ([]cloudscale.Server, error) {
 	client := meta.(*cloudscale.Client)
-	return client.Servers.List(context.Background())
+	return client.Servers.List(ctx)
 }

--- a/cloudscale/datasource_cloudscale_server_group.go
+++ b/cloudscale/datasource_cloudscale_server_group.go
@@ -19,7 +19,7 @@ func dataSourceCloudscaleServerGroup() *schema.Resource {
 	}
 }
 
-func listServerGroups(d *schema.ResourceData, meta any) ([]cloudscale.ServerGroup, error) {
+func listServerGroups(ctx context.Context, d *schema.ResourceData, meta any) ([]cloudscale.ServerGroup, error) {
 	client := meta.(*cloudscale.Client)
-	return client.ServerGroups.List(context.Background())
+	return client.ServerGroups.List(ctx)
 }

--- a/cloudscale/datasource_cloudscale_subnet.go
+++ b/cloudscale/datasource_cloudscale_subnet.go
@@ -19,7 +19,7 @@ func dataSourceCloudscaleSubnet() *schema.Resource {
 	}
 }
 
-func listSubnets(d *schema.ResourceData, meta any) ([]cloudscale.Subnet, error) {
+func listSubnets(ctx context.Context, d *schema.ResourceData, meta any) ([]cloudscale.Subnet, error) {
 	client := meta.(*cloudscale.Client)
-	return client.Subnets.List(context.Background())
+	return client.Subnets.List(ctx)
 }

--- a/cloudscale/datasource_cloudscale_volume.go
+++ b/cloudscale/datasource_cloudscale_volume.go
@@ -19,7 +19,7 @@ func dataSourceCloudscaleVolume() *schema.Resource {
 	}
 }
 
-func listVolumes(d *schema.ResourceData, meta any) ([]cloudscale.Volume, error) {
+func listVolumes(ctx context.Context, d *schema.ResourceData, meta any) ([]cloudscale.Volume, error) {
 	client := meta.(*cloudscale.Client)
-	return client.Volumes.List(context.Background())
+	return client.Volumes.List(ctx)
 }

--- a/cloudscale/datasource_cloudscale_volume_snapshot.go
+++ b/cloudscale/datasource_cloudscale_volume_snapshot.go
@@ -19,7 +19,7 @@ func dataSourceCloudscaleVolumeSnapshot() *schema.Resource {
 	}
 }
 
-func listVolumeSnapshots(d *schema.ResourceData, meta any) ([]cloudscale.VolumeSnapshot, error) {
+func listVolumeSnapshots(ctx context.Context, d *schema.ResourceData, meta any) ([]cloudscale.VolumeSnapshot, error) {
 	client := meta.(*cloudscale.Client)
-	return client.VolumeSnapshots.List(context.Background())
+	return client.VolumeSnapshots.List(ctx)
 }

--- a/cloudscale/datasources.go
+++ b/cloudscale/datasources.go
@@ -20,10 +20,10 @@ func fillResourceData(d *schema.ResourceData, map_ ResourceDataRaw) {
 func dataSourceResourceRead(
 	name string,
 	sourceSchema map[string]*schema.Schema,
-	fetchFunc func(d *schema.ResourceData, meta any) ([]ResourceDataRaw, error),
+	fetchFunc func(ctx context.Context, d *schema.ResourceData, meta any) ([]ResourceDataRaw, error),
 ) schema.ReadContextFunc {
 	return func(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-		resources, err := fetchFunc(d, meta)
+		resources, err := fetchFunc(ctx, d, meta)
 		if err != nil {
 			return diag.Errorf("Issue with fetching resources: %s", err)
 		}
@@ -58,11 +58,11 @@ func dataSourceResourceRead(
 }
 
 func getFetchFunc[TResource any](
-	listFunc func(d *schema.ResourceData, meta any) ([]TResource, error),
+	listFunc func(ctx context.Context, d *schema.ResourceData, meta any) ([]TResource, error),
 	gatherFunc func(resource *TResource) ResourceDataRaw,
-) func(d *schema.ResourceData, meta any) ([]ResourceDataRaw, error) {
-	return func(d *schema.ResourceData, meta any) ([]ResourceDataRaw, error) {
-		list, err := listFunc(d, meta)
+) func(ctx context.Context, d *schema.ResourceData, meta any) ([]ResourceDataRaw, error) {
+	return func(ctx context.Context, d *schema.ResourceData, meta any) ([]ResourceDataRaw, error) {
+		list, err := listFunc(ctx, d, meta)
 		if err != nil {
 			return nil, err
 		}

--- a/cloudscale/load_balancer_lock_utils.go
+++ b/cloudscale/load_balancer_lock_utils.go
@@ -1,0 +1,63 @@
+package cloudscale
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/cloudscale-ch/cloudscale-go-sdk/v9"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// The cloudscale API applies one change at a time to a load balancer. Creating,
+// updating or deleting any of its sub-resources (pools, pool members, listeners
+// and health monitors) mutates that same load balancer, so every such operation
+// has to serialize on the load balancer it belongs to. This file holds the lock
+// keys that make all of them agree on one key per load balancer.
+
+// lbLockKey returns the mutex key identifying a single load balancer. Every
+// operation that mutates the load balancer or any of its sub-resources locks on
+// this key, so they all have to derive it from the same load balancer UUID.
+func lbLockKey(lbUUID string) string {
+	return fmt.Sprintf("cloudscale/load-balancer/%s", lbUUID)
+}
+
+// lbGlobalLockUUID stands in for the load balancer UUID when the load balancer an
+// operation belongs to cannot be resolved. Locking on the resulting key serializes
+// the operation against every load balancer: slower than necessary, but correct,
+// whereas not locking at all would let it race with the load balancer it mutates.
+// The angle brackets keep it from ever colliding with a real UUID.
+const lbGlobalLockUUID = "<<global>>"
+
+// lockKeyFromLoadBalancerUUID serializes operations on the load balancer named by
+// the load_balancer_uuid attribute. It is meant for resources that carry that UUID
+// in their own schema, so the key is read straight from state without a lookup.
+var lockKeyFromLoadBalancerUUID = uuidLockKey("load_balancer_uuid", lbLockKey)
+
+// lockKeyFromPoolUUID serializes operations on the load balancer that owns the pool
+// named by the pool_uuid attribute. It is meant for resources whose schema has a
+// pool_uuid but no load_balancer_uuid, so their load balancer is not in state and has
+// to be resolved via the API to obtain the lock key. Such operations still mutate the
+// parent load balancer and must therefore serialize on it, not on the pool.
+//
+// The lookup is a read and runs before the lock is taken, so it cannot deadlock. If the
+// pool is there but its load balancer cannot be determined, the operation falls back to
+// lbGlobalLockUUID instead of running unserialized.
+func lockKeyFromPoolUUID(ctx context.Context, d *schema.ResourceData, meta any) (string, bool) {
+	poolUUID, ok := d.GetOk("pool_uuid")
+	if !ok {
+		log.Printf("[WARN] lockKeyFromPoolUUID: pool_uuid not set for resource %s, skipping lock", d.Id())
+		return "", false
+	}
+	client := meta.(*cloudscale.Client)
+	pool, err := client.LoadBalancerPools.Get(ctx, poolUUID.(string))
+	if err != nil {
+		log.Printf("[WARN] lockKeyFromPoolUUID: could not resolve load balancer for pool %s: %s; locking globally", poolUUID, err)
+		return lbLockKey(lbGlobalLockUUID), true
+	}
+	if pool.LoadBalancer.UUID == "" {
+		log.Printf("[WARN] lockKeyFromPoolUUID: pool %s has no load balancer, locking globally", poolUUID)
+		return lbLockKey(lbGlobalLockUUID), true
+	}
+	return lbLockKey(pool.LoadBalancer.UUID), true
+}

--- a/cloudscale/load_balancer_lock_utils.go
+++ b/cloudscale/load_balancer_lock_utils.go
@@ -3,17 +3,16 @@ package cloudscale
 import (
 	"context"
 	"fmt"
-	"log"
 
 	"github.com/cloudscale-ch/cloudscale-go-sdk/v9"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// The cloudscale API applies one change at a time to a load balancer. Creating,
-// updating or deleting any of its sub-resources (pools, pool members, listeners
-// and health monitors) mutates that same load balancer, so every such operation
-// has to serialize on the load balancer it belongs to. This file holds the lock
-// keys that make all of them agree on one key per load balancer.
+// The cloudscale API applies one change at a time to a load balancer, and every
+// sub-resource operation (pools, pool members, listeners, health monitors)
+// mutates its load balancer. Concurrency buys nothing here: the API serializes
+// the requests anyway; so we serialize them ourselves. This file derives the
+// lock keys for that: one per load balancer.
 
 // lbLockKey returns the mutex key identifying a single load balancer. Every
 // operation that mutates the load balancer or any of its sub-resources locks on
@@ -22,42 +21,27 @@ func lbLockKey(lbUUID string) string {
 	return fmt.Sprintf("cloudscale/load-balancer/%s", lbUUID)
 }
 
-// lbGlobalLockUUID stands in for the load balancer UUID when the load balancer an
-// operation belongs to cannot be resolved. Locking on the resulting key serializes
-// the operation against every load balancer: slower than necessary, but correct,
-// whereas not locking at all would let it race with the load balancer it mutates.
-// The angle brackets keep it from ever colliding with a real UUID.
-const lbGlobalLockUUID = "<<global>>"
-
-// lockKeyFromLoadBalancerUUID serializes operations on the load balancer named by
-// the load_balancer_uuid attribute. It is meant for resources that carry that UUID
-// in their own schema, so the key is read straight from state without a lookup.
+// lockKeyFromLoadBalancerUUID derives the lock key for the load balancer named by the
+// load_balancer_uuid attribute. It is for resources that carry that UUID in their own schema, so
+// the key comes straight from state without a lookup.
 var lockKeyFromLoadBalancerUUID = uuidLockKey("load_balancer_uuid", lbLockKey)
 
-// lockKeyFromPoolUUID serializes operations on the load balancer that owns the pool
-// named by the pool_uuid attribute. It is meant for resources whose schema has a
-// pool_uuid but no load_balancer_uuid, so their load balancer is not in state and has
-// to be resolved via the API to obtain the lock key. Such operations still mutate the
-// parent load balancer and must therefore serialize on it, not on the pool.
-//
-// The lookup is a read and runs before the lock is taken, so it cannot deadlock. If the
-// pool is there but its load balancer cannot be determined, the operation falls back to
-// lbGlobalLockUUID instead of running unserialized.
-func lockKeyFromPoolUUID(ctx context.Context, d *schema.ResourceData, meta any) (string, bool) {
+// lockKeyFromPoolUUID derives the lock key for the load balancer that owns the pool named by
+// pool_uuid. It is for resources that carry pool_uuid but not load_balancer_uuid, so the load
+// balancer is resolved via the API. It returns an error when the load balancer can't be determined,
+// e.g.: pool_uuid unset, the lookup fails, or the pool has no load balancer.
+func lockKeyFromPoolUUID(ctx context.Context, d *schema.ResourceData, meta any) (string, error) {
 	poolUUID, ok := d.GetOk("pool_uuid")
 	if !ok {
-		log.Printf("[WARN] lockKeyFromPoolUUID: pool_uuid not set for resource %s, skipping lock", d.Id())
-		return "", false
+		return "", fmt.Errorf("cannot determine the load balancer to lock: pool_uuid is not set")
 	}
 	client := meta.(*cloudscale.Client)
 	pool, err := client.LoadBalancerPools.Get(ctx, poolUUID.(string))
 	if err != nil {
-		log.Printf("[WARN] lockKeyFromPoolUUID: could not resolve load balancer for pool %s: %s; locking globally", poolUUID, err)
-		return lbLockKey(lbGlobalLockUUID), true
+		return "", fmt.Errorf("cannot determine the load balancer to lock for pool %s: %w", poolUUID, err)
 	}
 	if pool.LoadBalancer.UUID == "" {
-		log.Printf("[WARN] lockKeyFromPoolUUID: pool %s has no load balancer, locking globally", poolUUID)
-		return lbLockKey(lbGlobalLockUUID), true
+		return "", fmt.Errorf("cannot determine the load balancer to lock: pool %s has no load balancer", poolUUID)
 	}
-	return lbLockKey(pool.LoadBalancer.UUID), true
+	return lbLockKey(pool.LoadBalancer.UUID), nil
 }

--- a/cloudscale/load_balancer_lock_utils_test.go
+++ b/cloudscale/load_balancer_lock_utils_test.go
@@ -1,0 +1,216 @@
+package cloudscale
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/cloudscale-ch/cloudscale-go-sdk/v9"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// testClient returns a cloudscale client whose requests are served by handler
+// instead of the real API.
+func testClient(t *testing.T, handler http.Handler) *cloudscale.Client {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	// The trailing slash matters: the SDK builds request URLs with
+	// BaseURL.ResolveReference(), which would otherwise drop the last segment.
+	baseURL, err := url.Parse(server.URL + "/")
+	if err != nil {
+		t.Fatalf("parsing test server URL: %s", err)
+	}
+
+	client := cloudscale.NewClient(nil)
+	client.BaseURL = baseURL
+	return client
+}
+
+// poolHandler serves one pool at the path the SDK uses for pool reads.
+func poolHandler(t *testing.T, poolUUID string, pool cloudscale.LoadBalancerPool) http.Handler {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/load-balancers/pools/"+poolUUID, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(pool); err != nil {
+			t.Errorf("encoding pool response: %s", err)
+		}
+	})
+	return mux
+}
+
+func TestLbLockKey(t *testing.T) {
+	if got, want := lbLockKey("abc"), "cloudscale/load-balancer/abc"; got != want {
+		t.Errorf("lbLockKey() = %q, want %q", got, want)
+	}
+}
+
+func TestUuidLockKey(t *testing.T) {
+	keyFunc := uuidLockKey("load_balancer_uuid", lbLockKey)
+	poolSchema := getLoadBalancerPoolSchema(RESOURCE)
+
+	t.Run("derives the key from the attribute", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, poolSchema, map[string]any{
+			"load_balancer_uuid": "lb-1",
+		})
+
+		// meta is intentionally nil: reading an attribute must not need a client.
+		key, ok := keyFunc(context.Background(), d, nil)
+		if !ok {
+			t.Fatal("expected a lock key")
+		}
+		if want := "cloudscale/load-balancer/lb-1"; key != want {
+			t.Errorf("key = %q, want %q", key, want)
+		}
+	})
+
+	t.Run("skips locking when the attribute is unset", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, poolSchema, map[string]any{})
+
+		if _, ok := keyFunc(context.Background(), d, nil); ok {
+			t.Error("expected locking to be skipped rather than locking on an empty key")
+		}
+	})
+}
+
+func TestLockKeyFromPoolUUID(t *testing.T) {
+	const (
+		poolUUID = "pool-1"
+		lbUUID   = "lb-1"
+	)
+	memberSchema := getLoadBalancerPoolMemberSchema(RESOURCE)
+
+	t.Run("resolves the load balancer that owns the pool", func(t *testing.T) {
+		client := testClient(t, poolHandler(t, poolUUID, cloudscale.LoadBalancerPool{
+			UUID:         poolUUID,
+			LoadBalancer: cloudscale.LoadBalancerStub{UUID: lbUUID},
+		}))
+		d := schema.TestResourceDataRaw(t, memberSchema, map[string]any{"pool_uuid": poolUUID})
+
+		key, ok := lockKeyFromPoolUUID(context.Background(), d, client)
+		if !ok {
+			t.Fatal("expected a lock key")
+		}
+		if want := "cloudscale/load-balancer/lb-1"; key != want {
+			t.Errorf("key = %q, want %q", key, want)
+		}
+	})
+
+	t.Run("skips locking when pool_uuid is unset", func(t *testing.T) {
+		client := testClient(t, http.NewServeMux())
+		d := schema.TestResourceDataRaw(t, memberSchema, map[string]any{})
+
+		if _, ok := lockKeyFromPoolUUID(context.Background(), d, client); ok {
+			t.Error("expected locking to be skipped when pool_uuid is unset")
+		}
+	})
+
+	// A failed resolution must not drop the lock: the operation still mutates some
+	// load balancer, we just cannot tell which one. Falling back to a global key
+	// serializes it against every load balancer, which is slow but correct.
+	t.Run("locks globally when the pool cannot be read", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, `{"detail": "boom"}`, http.StatusInternalServerError)
+		})
+		client := testClient(t, mux)
+		d := schema.TestResourceDataRaw(t, memberSchema, map[string]any{"pool_uuid": poolUUID})
+
+		key, ok := lockKeyFromPoolUUID(context.Background(), d, client)
+		if !ok {
+			t.Fatal("expected a global lock key rather than no locking at all")
+		}
+		if want := "cloudscale/load-balancer/<<global>>"; key != want {
+			t.Errorf("key = %q, want %q", key, want)
+		}
+	})
+
+	// Every pool has a load balancer, so an empty UUID here is a malformed response
+	// rather than a pool without one: the same failed resolution as above, just
+	// detected in the payload instead of the transport.
+	t.Run("locks globally when the pool has no load balancer", func(t *testing.T) {
+		client := testClient(t, poolHandler(t, poolUUID, cloudscale.LoadBalancerPool{
+			UUID: poolUUID,
+		}))
+		d := schema.TestResourceDataRaw(t, memberSchema, map[string]any{"pool_uuid": poolUUID})
+
+		key, ok := lockKeyFromPoolUUID(context.Background(), d, client)
+		if !ok {
+			t.Fatal("expected a global lock key rather than no locking at all")
+		}
+		if want := "cloudscale/load-balancer/<<global>>"; key != want {
+			t.Errorf("key = %q, want %q", key, want)
+		}
+	})
+}
+
+// TestLoadBalancerSubResourcesShareLockKey is the regression test for the bug
+// where pool members and listeners serialized on their pool while pools
+// serialized on the load balancer, so operations on one load balancer never
+// blocked each other. Every load balancer sub-resource must derive the same key.
+func TestLoadBalancerSubResourcesShareLockKey(t *testing.T) {
+	const (
+		poolUUID = "pool-1"
+		lbUUID   = "lb-1"
+	)
+
+	client := testClient(t, poolHandler(t, poolUUID, cloudscale.LoadBalancerPool{
+		UUID:         poolUUID,
+		LoadBalancer: cloudscale.LoadBalancerStub{UUID: lbUUID},
+	}))
+
+	tests := []struct {
+		name        string
+		resSchema   map[string]*schema.Schema
+		raw         map[string]any
+		lockKeyFunc mutexKeyFunc
+	}{
+		{
+			name:        "pool",
+			resSchema:   getLoadBalancerPoolSchema(RESOURCE),
+			raw:         map[string]any{"load_balancer_uuid": lbUUID},
+			lockKeyFunc: lockKeyFromLoadBalancerUUID,
+		},
+		{
+			name:        "pool member",
+			resSchema:   getLoadBalancerPoolMemberSchema(RESOURCE),
+			raw:         map[string]any{"pool_uuid": poolUUID},
+			lockKeyFunc: lockKeyFromPoolUUID,
+		},
+		{
+			name:        "listener",
+			resSchema:   getLoadBalancerListenerSchema(RESOURCE),
+			raw:         map[string]any{"pool_uuid": poolUUID},
+			lockKeyFunc: lockKeyFromPoolUUID,
+		},
+		{
+			name:        "health monitor",
+			resSchema:   getLoadBalancerHealthMonitorSchema(RESOURCE),
+			raw:         map[string]any{"pool_uuid": poolUUID},
+			lockKeyFunc: lockKeyFromPoolUUID,
+		},
+	}
+
+	const want = "cloudscale/load-balancer/lb-1"
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := schema.TestResourceDataRaw(t, tt.resSchema, tt.raw)
+
+			key, ok := tt.lockKeyFunc(context.Background(), d, client)
+			if !ok {
+				t.Fatalf("%s: locking was skipped, so its operations run unserialized", tt.name)
+			}
+			if key != want {
+				t.Errorf("%s locks on %q, want %q: every load balancer sub-resource must serialize on the same key",
+					tt.name, key, want)
+			}
+		})
+	}
+}

--- a/cloudscale/load_balancer_lock_utils_test.go
+++ b/cloudscale/load_balancer_lock_utils_test.go
@@ -62,20 +62,22 @@ func TestUuidLockKey(t *testing.T) {
 		})
 
 		// meta is intentionally nil: reading an attribute must not need a client.
-		key, ok := keyFunc(context.Background(), d, nil)
-		if !ok {
-			t.Fatal("expected a lock key")
+		key, err := keyFunc(context.Background(), d, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
 		}
 		if want := "cloudscale/load-balancer/lb-1"; key != want {
 			t.Errorf("key = %q, want %q", key, want)
 		}
 	})
 
-	t.Run("skips locking when the attribute is unset", func(t *testing.T) {
+	t.Run("errors when the attribute is unset", func(t *testing.T) {
 		d := schema.TestResourceDataRaw(t, poolSchema, map[string]any{})
 
-		if _, ok := keyFunc(context.Background(), d, nil); ok {
-			t.Error("expected locking to be skipped rather than locking on an empty key")
+		// The attribute is Required, so an unset value is a coding error: fail rather than
+		// lock on a meaningless key.
+		if _, err := keyFunc(context.Background(), d, nil); err == nil {
+			t.Error("expected an error when the attribute is unset")
 		}
 	})
 }
@@ -94,28 +96,27 @@ func TestLockKeyFromPoolUUID(t *testing.T) {
 		}))
 		d := schema.TestResourceDataRaw(t, memberSchema, map[string]any{"pool_uuid": poolUUID})
 
-		key, ok := lockKeyFromPoolUUID(context.Background(), d, client)
-		if !ok {
-			t.Fatal("expected a lock key")
+		key, err := lockKeyFromPoolUUID(context.Background(), d, client)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
 		}
 		if want := "cloudscale/load-balancer/lb-1"; key != want {
 			t.Errorf("key = %q, want %q", key, want)
 		}
 	})
 
-	t.Run("skips locking when pool_uuid is unset", func(t *testing.T) {
+	t.Run("errors when pool_uuid is unset", func(t *testing.T) {
 		client := testClient(t, http.NewServeMux())
 		d := schema.TestResourceDataRaw(t, memberSchema, map[string]any{})
 
-		if _, ok := lockKeyFromPoolUUID(context.Background(), d, client); ok {
-			t.Error("expected locking to be skipped when pool_uuid is unset")
+		if _, err := lockKeyFromPoolUUID(context.Background(), d, client); err == nil {
+			t.Error("expected an error when pool_uuid is unset")
 		}
 	})
 
-	// A failed resolution must not drop the lock: the operation still mutates some
-	// load balancer, we just cannot tell which one. Falling back to a global key
-	// serializes it against every load balancer, which is slow but correct.
-	t.Run("locks globally when the pool cannot be read", func(t *testing.T) {
+	// The load balancer can't be determined, so the operation must fail rather than run
+	// unserialized: we can't tell which load balancer it would mutate.
+	t.Run("errors when the pool cannot be read", func(t *testing.T) {
 		mux := http.NewServeMux()
 		mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
 			http.Error(w, `{"detail": "boom"}`, http.StatusInternalServerError)
@@ -123,30 +124,22 @@ func TestLockKeyFromPoolUUID(t *testing.T) {
 		client := testClient(t, mux)
 		d := schema.TestResourceDataRaw(t, memberSchema, map[string]any{"pool_uuid": poolUUID})
 
-		key, ok := lockKeyFromPoolUUID(context.Background(), d, client)
-		if !ok {
-			t.Fatal("expected a global lock key rather than no locking at all")
-		}
-		if want := "cloudscale/load-balancer/<<global>>"; key != want {
-			t.Errorf("key = %q, want %q", key, want)
+		if _, err := lockKeyFromPoolUUID(context.Background(), d, client); err == nil {
+			t.Error("expected an error when the pool cannot be read")
 		}
 	})
 
 	// Every pool has a load balancer, so an empty UUID here is a malformed response
 	// rather than a pool without one: the same failed resolution as above, just
 	// detected in the payload instead of the transport.
-	t.Run("locks globally when the pool has no load balancer", func(t *testing.T) {
+	t.Run("errors when the pool has no load balancer", func(t *testing.T) {
 		client := testClient(t, poolHandler(t, poolUUID, cloudscale.LoadBalancerPool{
 			UUID: poolUUID,
 		}))
 		d := schema.TestResourceDataRaw(t, memberSchema, map[string]any{"pool_uuid": poolUUID})
 
-		key, ok := lockKeyFromPoolUUID(context.Background(), d, client)
-		if !ok {
-			t.Fatal("expected a global lock key rather than no locking at all")
-		}
-		if want := "cloudscale/load-balancer/<<global>>"; key != want {
-			t.Errorf("key = %q, want %q", key, want)
+		if _, err := lockKeyFromPoolUUID(context.Background(), d, client); err == nil {
+			t.Error("expected an error when the pool has no load balancer")
 		}
 	})
 }
@@ -203,9 +196,9 @@ func TestLoadBalancerSubResourcesShareLockKey(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			d := schema.TestResourceDataRaw(t, tt.resSchema, tt.raw)
 
-			key, ok := tt.lockKeyFunc(context.Background(), d, client)
-			if !ok {
-				t.Fatalf("%s: locking was skipped, so its operations run unserialized", tt.name)
+			key, err := tt.lockKeyFunc(context.Background(), d, client)
+			if err != nil {
+				t.Fatalf("%s: %s", tt.name, err)
 			}
 			if key != want {
 				t.Errorf("%s locks on %q, want %q: every load balancer sub-resource must serialize on the same key",

--- a/cloudscale/mutex_kv.go
+++ b/cloudscale/mutex_kv.go
@@ -1,8 +1,11 @@
 package cloudscale
 
 import (
+	"context"
+	"fmt"
 	"log"
 	"sync"
+	"time"
 )
 
 // Source: https://developer.hashicorp.com/terraform/plugin/sdkv2/guides/v2-upgrade-guide#removal-of-helper-mutexkv-package
@@ -19,15 +22,26 @@ type MutexKV struct {
 	store map[string]*sync.Mutex
 }
 
-// Locks the mutex for the given key. Caller is responsible for calling Unlock
-// for the same key
-func (m *MutexKV) Lock(key string) {
+// LockContext tries to acquire the mutex for the given key, retrying until the
+// context is done. Returns an error if the context deadline is exceeded before
+// the lock is acquired.
+func (m *MutexKV) LockContext(ctx context.Context, key string) error {
 	log.Printf("[DEBUG] Locking %q", key)
-	m.get(key).Lock()
-	log.Printf("[DEBUG] Locked %q", key)
+	mu := m.get(key)
+	for {
+		if mu.TryLock() {
+			log.Printf("[DEBUG] Locked %q", key)
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting to acquire lock %q: %w", key, ctx.Err())
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
 }
 
-// Unlock the mutex for the given key. Caller must have called Lock for the same key first
+// Unlock the mutex for the given key. Caller must have called LockContext for the same key first
 func (m *MutexKV) Unlock(key string) {
 	log.Printf("[DEBUG] Unlocking %q", key)
 	m.get(key).Unlock()

--- a/cloudscale/mutex_kv.go
+++ b/cloudscale/mutex_kv.go
@@ -5,65 +5,69 @@ import (
 	"fmt"
 	"log"
 	"sync"
-	"time"
 )
 
-// Source: https://developer.hashicorp.com/terraform/plugin/sdkv2/guides/v2-upgrade-guide#removal-of-helper-mutexkv-package
-// License: public domain
-
-// MutexKV is a simple key/value store for arbitrary mutexes. It can be used to
-// serialize changes across arbitrary collaborators that share knowledge of the
-// keys they must serialize on.
+// MutexKV is a simple key/value store for per-key mutexes. It can be used to
+// serialize changes across collaborators that share knowledge of the keys they
+// must serialize on.
 //
-// The initial use case is to let aws_security_group_rule resources serialize
-// their access to individual security groups based on SG ID.
+// Each key is backed by a buffered channel of size 1. Sending to the channel
+// acquires the lock; receiving from it releases it. The channel size of 1 is
+// the critical invariant: it allows exactly one sender to hold the lock at a
+// time, while any additional senders block until the slot is freed.
+//
+// Inspired by the Hashicorp helper/mutexkv package (public domain,
+// https://developer.hashicorp.com/terraform/plugin/sdkv2/guides/v2-upgrade-guide#removal-of-helper-mutexkv-package), but
+// rewritten to use channels (the idiomatic Go approach to synchronization:
+// "don't communicate by sharing memory; share memory by communicating")
+// so that LockContext can respect context cancellation without polling.
 type MutexKV struct {
 	lock  sync.Mutex
-	store map[string]*sync.Mutex
+	store map[string]chan struct{}
 }
 
-// LockContext tries to acquire the mutex for the given key, retrying until the
-// context is done. Returns an error if the context deadline is exceeded before
-// the lock is acquired.
+// LockContext tries to acquire the mutex for the given key, blocking until the
+// lock is acquired or the context is done. Returns an error if the context is
+// cancelled or its deadline is exceeded before the lock is acquired.
 func (m *MutexKV) LockContext(ctx context.Context, key string) error {
 	log.Printf("[DEBUG] Locking %q", key)
-	mu := m.get(key)
-	for {
-		if mu.TryLock() {
-			log.Printf("[DEBUG] Locked %q", key)
-			return nil
-		}
-		select {
-		case <-ctx.Done():
-			return fmt.Errorf("timed out waiting to acquire lock %q: %w", key, ctx.Err())
-		case <-time.After(50 * time.Millisecond):
-		}
+	c := m.get(key)
+	select {
+	case c <- struct{}{}:
+		log.Printf("[DEBUG] Locked %q", key)
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("timed out waiting to acquire lock %q: %w", key, ctx.Err())
 	}
 }
 
 // Unlock the mutex for the given key. Caller must have called LockContext for the same key first
 func (m *MutexKV) Unlock(key string) {
 	log.Printf("[DEBUG] Unlocking %q", key)
-	m.get(key).Unlock()
-	log.Printf("[DEBUG] Unlocked %q", key)
+	select {
+	case <-m.get(key):
+		log.Printf("[DEBUG] Unlocked %q", key)
+	default:
+		panic(fmt.Sprintf("Unlock of unlocked key %q", key))
+	}
 }
 
-// Returns a mutex for the given key, no guarantee of its lock status
-func (m *MutexKV) get(key string) *sync.Mutex {
+// Returns a channel for the given key, no guarantee of its lock status
+func (m *MutexKV) get(key string) chan struct{} {
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	mutex, ok := m.store[key]
+	c, ok := m.store[key]
 	if !ok {
-		mutex = &sync.Mutex{}
-		m.store[key] = mutex
+		c = make(chan struct{}, 1) // size 1: allows exactly one holder at a time
+		m.store[key] = c
 	}
-	return mutex
+	return c
 }
 
 // Returns a properly initialized MutexKV
 func NewMutexKV() *MutexKV {
 	return &MutexKV{
-		store: make(map[string]*sync.Mutex),
+		store: make(map[string]chan struct{}),
 	}
 }
 

--- a/cloudscale/resource_cloudscale_custom_image.go
+++ b/cloudscale/resource_cloudscale_custom_image.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/cloudscale-ch/cloudscale-go-sdk/v9"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -22,8 +23,8 @@ var (
 
 func resourceCloudscaleCustomImage() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceCustomImageCreate,
-		Read:   resourceCustomImageRead,
+		CreateContext: resourceCustomImageCreate,
+		ReadContext:   resourceCustomImageRead,
 		UpdateContext: resourceCustomImageUpdate,
 		DeleteContext: resourceCustomImageDelete,
 
@@ -113,7 +114,7 @@ func getCustomImageSchema(t SchemaType) map[string]*schema.Schema {
 	return m
 }
 
-func resourceCustomImageCreate(d *schema.ResourceData, meta any) error {
+func resourceCustomImageCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	timeout := d.Timeout(schema.TimeoutCreate)
 	startTime := time.Now()
 
@@ -143,9 +144,9 @@ func resourceCustomImageCreate(d *schema.ResourceData, meta any) error {
 
 	log.Printf("[DEBUG] CustomImage create configuration: %#v", opts)
 
-	customImageImport, err := client.CustomImageImports.Create(context.Background(), opts)
+	customImageImport, err := client.CustomImageImports.Create(ctx, opts)
 	if err != nil {
-		return fmt.Errorf("Error creating customImageImport: %z", err)
+		return diag.FromErr(fmt.Errorf("Error creating customImageImport: %z", err))
 	}
 
 	d.SetId(customImageImport.CustomImage.UUID)
@@ -155,15 +156,15 @@ func resourceCustomImageCreate(d *schema.ResourceData, meta any) error {
 	remainingTime := timeout - time.Since(startTime)
 	_, err = waitForCustomImageImportStatus(ctx, customImageImport.UUID, d, meta, []string{"in_progress"}, "import_status", "success", remainingTime)
 	if err != nil {
-		return fmt.Errorf("Error waiting for custom image import status (%s) (%s) ", customImageImport.UUID, err)
+		return diag.FromErr(fmt.Errorf("Error waiting for custom image import status (%s) (%s) ", customImageImport.UUID, err))
 	}
-	customImageImport, err = client.CustomImageImports.Get(context.Background(), customImageImport.UUID)
+	customImageImport, err = client.CustomImageImports.Get(ctx, customImageImport.UUID)
 	if err != nil {
-		return fmt.Errorf("Error getting customImage: %z", err)
+		return diag.FromErr(fmt.Errorf("Error getting customImage: %z", err))
 	}
-	customImage, err := client.CustomImages.Get(context.Background(), customImageImport.CustomImage.UUID)
+	customImage, err := client.CustomImages.Get(ctx, customImageImport.CustomImage.UUID)
 	if err != nil {
-		return fmt.Errorf("Error getting customImage: %z", err)
+		return diag.FromErr(fmt.Errorf("Error getting customImage: %z", err))
 	}
 
 	fillCustomImageResourceData(d, customImageImport, customImage)
@@ -200,9 +201,9 @@ func gatherCustomImageResourceData(customImage *cloudscale.CustomImage) Resource
 	return m
 }
 
-func readCustomImage(rId GenericResourceIdentifier, meta any) (*cloudscale.CustomImage, error) {
+func readCustomImage(ctx context.Context, rId GenericResourceIdentifier, meta any) (*cloudscale.CustomImage, error) {
 	client := meta.(*cloudscale.Client)
-	return client.CustomImages.Get(context.Background(), rId.Id)
+	return client.CustomImages.Get(ctx, rId.Id)
 }
 
 func updateCustomImage(ctx context.Context, rId GenericResourceIdentifier, meta any, updateRequest *cloudscale.CustomImageRequest) error {

--- a/cloudscale/resource_cloudscale_custom_image.go
+++ b/cloudscale/resource_cloudscale_custom_image.go
@@ -16,6 +16,7 @@ import (
 const customImageHumanName = "custom image"
 
 var (
+	resourceCustomImageCreate = getCreateOperation(createCustomImage, nil)
 	resourceCustomImageRead   = getReadOperation(customImageHumanName, getGenericResourceIdentifierFromSchema, readCustomImage, gatherCustomImageResourceData)
 	resourceCustomImageUpdate = getUpdateOperation(customImageHumanName, getGenericResourceIdentifierFromSchema, updateCustomImage, resourceCustomImageRead, gatherCustomImageUpdateRequest, nil)
 	resourceCustomImageDelete = getDeleteOperation(customImageHumanName, getGenericResourceIdentifierFromSchema, deleteCustomImage, nil)
@@ -114,7 +115,7 @@ func getCustomImageSchema(t SchemaType) map[string]*schema.Schema {
 	return m
 }
 
-func resourceCustomImageCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func createCustomImage(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	timeout := d.Timeout(schema.TimeoutCreate)
 	startTime := time.Now()
 

--- a/cloudscale/resource_cloudscale_custom_image.go
+++ b/cloudscale/resource_cloudscale_custom_image.go
@@ -16,8 +16,8 @@ const customImageHumanName = "custom image"
 
 var (
 	resourceCustomImageRead   = getReadOperation(customImageHumanName, getGenericResourceIdentifierFromSchema, readCustomImage, gatherCustomImageResourceData)
-	resourceCustomImageUpdate = getUpdateOperation(customImageHumanName, getGenericResourceIdentifierFromSchema, updateCustomImage, resourceCustomImageRead, gatherCustomImageUpdateRequest)
-	resourceCustomImageDelete = getDeleteOperation(customImageHumanName, deleteCustomImage)
+	resourceCustomImageUpdate = getUpdateOperation(customImageHumanName, getGenericResourceIdentifierFromSchema, updateCustomImage, resourceCustomImageRead, gatherCustomImageUpdateRequest, nil)
+	resourceCustomImageDelete = getDeleteOperation(customImageHumanName, getGenericResourceIdentifierFromSchema, deleteCustomImage, nil)
 )
 
 func resourceCloudscaleCustomImage() *schema.Resource {
@@ -233,10 +233,9 @@ func gatherCustomImageUpdateRequest(d *schema.ResourceData) []*cloudscale.Custom
 	return requests
 }
 
-func deleteCustomImage(d *schema.ResourceData, meta any) error {
+func deleteCustomImage(rId GenericResourceIdentifier, meta any) error {
 	client := meta.(*cloudscale.Client)
-	id := d.Id()
-	return client.CustomImages.Delete(context.Background(), id)
+	return client.CustomImages.Delete(context.Background(), rId.Id)
 }
 
 func waitForCustomImageImportStatus(uuid string, d *schema.ResourceData, meta any, pending []string, attribute, target string, timeout time.Duration) (any, error) {

--- a/cloudscale/resource_cloudscale_custom_image.go
+++ b/cloudscale/resource_cloudscale_custom_image.go
@@ -24,8 +24,8 @@ func resourceCloudscaleCustomImage() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceCustomImageCreate,
 		Read:   resourceCustomImageRead,
-		Update: resourceCustomImageUpdate,
-		Delete: resourceCustomImageDelete,
+		UpdateContext: resourceCustomImageUpdate,
+		DeleteContext: resourceCustomImageDelete,
 
 		Schema: getCustomImageSchema(RESOURCE),
 		Timeouts: &schema.ResourceTimeout{
@@ -153,7 +153,7 @@ func resourceCustomImageCreate(d *schema.ResourceData, meta any) error {
 	log.Printf("[INFO] CustomImage ID %s", d.Id())
 
 	remainingTime := timeout - time.Since(startTime)
-	_, err = waitForCustomImageImportStatus(customImageImport.UUID, d, meta, []string{"in_progress"}, "import_status", "success", remainingTime)
+	_, err = waitForCustomImageImportStatus(ctx, customImageImport.UUID, d, meta, []string{"in_progress"}, "import_status", "success", remainingTime)
 	if err != nil {
 		return fmt.Errorf("Error waiting for custom image import status (%s) (%s) ", customImageImport.UUID, err)
 	}
@@ -205,9 +205,9 @@ func readCustomImage(rId GenericResourceIdentifier, meta any) (*cloudscale.Custo
 	return client.CustomImages.Get(context.Background(), rId.Id)
 }
 
-func updateCustomImage(rId GenericResourceIdentifier, meta any, updateRequest *cloudscale.CustomImageRequest) error {
+func updateCustomImage(ctx context.Context, rId GenericResourceIdentifier, meta any, updateRequest *cloudscale.CustomImageRequest) error {
 	client := meta.(*cloudscale.Client)
-	return client.CustomImages.Update(context.Background(), rId.Id, updateRequest)
+	return client.CustomImages.Update(ctx, rId.Id, updateRequest)
 }
 
 func gatherCustomImageUpdateRequest(d *schema.ResourceData) []*cloudscale.CustomImageRequest {
@@ -233,12 +233,12 @@ func gatherCustomImageUpdateRequest(d *schema.ResourceData) []*cloudscale.Custom
 	return requests
 }
 
-func deleteCustomImage(rId GenericResourceIdentifier, meta any) error {
+func deleteCustomImage(ctx context.Context, rId GenericResourceIdentifier, meta any) error {
 	client := meta.(*cloudscale.Client)
-	return client.CustomImages.Delete(context.Background(), rId.Id)
+	return client.CustomImages.Delete(ctx, rId.Id)
 }
 
-func waitForCustomImageImportStatus(uuid string, d *schema.ResourceData, meta any, pending []string, attribute, target string, timeout time.Duration) (any, error) {
+func waitForCustomImageImportStatus(ctx context.Context, uuid string, d *schema.ResourceData, meta any, pending []string, attribute, target string, timeout time.Duration) (any, error) {
 	log.Printf(
 		"[INFO] Waiting %s for custom image import (%s) to have %s of %s",
 		timeout, uuid, attribute, target)
@@ -246,20 +246,20 @@ func waitForCustomImageImportStatus(uuid string, d *schema.ResourceData, meta an
 	stateConf := &resource.StateChangeConf{
 		Pending:        pending,
 		Target:         []string{target},
-		Refresh:        newCustomImageImportRefreshFunc(uuid, d, attribute, meta),
+		Refresh:        newCustomImageImportRefreshFunc(ctx, uuid, d, attribute, meta),
 		Timeout:        timeout,
 		Delay:          10 * time.Second,
 		MinTimeout:     10 * time.Second,
 		NotFoundChecks: math.MaxInt32,
 	}
 
-	return stateConf.WaitForState()
+	return stateConf.WaitForStateContext(ctx)
 }
 
-func newCustomImageImportRefreshFunc(uuid string, d *schema.ResourceData, attribute string, meta any) resource.StateRefreshFunc {
+func newCustomImageImportRefreshFunc(ctx context.Context, uuid string, d *schema.ResourceData, attribute string, meta any) resource.StateRefreshFunc {
 	client := meta.(*cloudscale.Client)
 	return func() (any, string, error) {
-		customImageImport, err := client.CustomImageImports.Get(context.Background(), uuid)
+		customImageImport, err := client.CustomImageImports.Get(ctx, uuid)
 		if err != nil {
 			return nil, "", fmt.Errorf("Error retrieving customImageImport (%s) (refresh) %s", uuid, err)
 		}

--- a/cloudscale/resource_cloudscale_floating_ip.go
+++ b/cloudscale/resource_cloudscale_floating_ip.go
@@ -13,8 +13,8 @@ const floatingIPHumanName = "Floating IP"
 
 var (
 	resourceFloatingIPRead   = getReadOperation(floatingIPHumanName, getGenericResourceIdentifierFromSchema, readFloatingIP, gatherFloatingIPResourceData)
-	resourceFloatingIPUpdate = getUpdateOperation(floatingIPHumanName, getGenericResourceIdentifierFromSchema, updateFloatingIP, resourceFloatingIPRead, gatherFloatingIPUpdateRequest)
-	resourceFloatingIPDelete = getDeleteOperation(floatingIPHumanName, deleteFloatingIP)
+	resourceFloatingIPUpdate = getUpdateOperation(floatingIPHumanName, getGenericResourceIdentifierFromSchema, updateFloatingIP, resourceFloatingIPRead, gatherFloatingIPUpdateRequest, nil)
+	resourceFloatingIPDelete = getDeleteOperation(floatingIPHumanName, getGenericResourceIdentifierFromSchema, deleteFloatingIP, nil)
 )
 
 func resourceCloudscaleFloatingIP() *schema.Resource {
@@ -212,8 +212,7 @@ func gatherFloatingIPUpdateRequest(d *schema.ResourceData) []*cloudscale.Floatin
 	return requests
 }
 
-func deleteFloatingIP(d *schema.ResourceData, meta any) error {
+func deleteFloatingIP(rId GenericResourceIdentifier, meta any) error {
 	client := meta.(*cloudscale.Client)
-	id := d.Id()
-	return client.FloatingIPs.Delete(context.Background(), id)
+	return client.FloatingIPs.Delete(context.Background(), rId.Id)
 }

--- a/cloudscale/resource_cloudscale_floating_ip.go
+++ b/cloudscale/resource_cloudscale_floating_ip.go
@@ -13,6 +13,7 @@ import (
 const floatingIPHumanName = "Floating IP"
 
 var (
+	resourceFloatingIPCreate = getCreateOperation(createFloatingIP, nil)
 	resourceFloatingIPRead   = getReadOperation(floatingIPHumanName, getGenericResourceIdentifierFromSchema, readFloatingIP, gatherFloatingIPResourceData)
 	resourceFloatingIPUpdate = getUpdateOperation(floatingIPHumanName, getGenericResourceIdentifierFromSchema, updateFloatingIP, resourceFloatingIPRead, gatherFloatingIPUpdateRequest, nil)
 	resourceFloatingIPDelete = getDeleteOperation(floatingIPHumanName, getGenericResourceIdentifierFromSchema, deleteFloatingIP, nil)
@@ -97,7 +98,7 @@ func getFloatingIPSchema(t SchemaType) map[string]*schema.Schema {
 	return m
 }
 
-func resourceFloatingIPCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func createFloatingIP(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*cloudscale.Client)
 
 	opts := &cloudscale.FloatingIPCreateRequest{

--- a/cloudscale/resource_cloudscale_floating_ip.go
+++ b/cloudscale/resource_cloudscale_floating_ip.go
@@ -21,8 +21,8 @@ func resourceCloudscaleFloatingIP() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceFloatingIPCreate,
 		Read:   resourceFloatingIPRead,
-		Update: resourceFloatingIPUpdate,
-		Delete: resourceFloatingIPDelete,
+		UpdateContext: resourceFloatingIPUpdate,
+		DeleteContext: resourceFloatingIPDelete,
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -177,9 +177,9 @@ func readFloatingIP(rId GenericResourceIdentifier, meta any) (*cloudscale.Floati
 
 }
 
-func updateFloatingIP(rId GenericResourceIdentifier, meta any, updateRequest *cloudscale.FloatingIPUpdateRequest) error {
+func updateFloatingIP(ctx context.Context, rId GenericResourceIdentifier, meta any, updateRequest *cloudscale.FloatingIPUpdateRequest) error {
 	client := meta.(*cloudscale.Client)
-	return client.FloatingIPs.Update(context.Background(), rId.Id, updateRequest)
+	return client.FloatingIPs.Update(ctx, rId.Id, updateRequest)
 }
 
 func gatherFloatingIPUpdateRequest(d *schema.ResourceData) []*cloudscale.FloatingIPUpdateRequest {
@@ -212,7 +212,7 @@ func gatherFloatingIPUpdateRequest(d *schema.ResourceData) []*cloudscale.Floatin
 	return requests
 }
 
-func deleteFloatingIP(rId GenericResourceIdentifier, meta any) error {
+func deleteFloatingIP(ctx context.Context, rId GenericResourceIdentifier, meta any) error {
 	client := meta.(*cloudscale.Client)
-	return client.FloatingIPs.Delete(context.Background(), rId.Id)
+	return client.FloatingIPs.Delete(ctx, rId.Id)
 }

--- a/cloudscale/resource_cloudscale_floating_ip.go
+++ b/cloudscale/resource_cloudscale_floating_ip.go
@@ -6,6 +6,7 @@ import (
 	"log"
 
 	"github.com/cloudscale-ch/cloudscale-go-sdk/v9"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -19,8 +20,8 @@ var (
 
 func resourceCloudscaleFloatingIP() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceFloatingIPCreate,
-		Read:   resourceFloatingIPRead,
+		CreateContext: resourceFloatingIPCreate,
+		ReadContext:   resourceFloatingIPRead,
 		UpdateContext: resourceFloatingIPUpdate,
 		DeleteContext: resourceFloatingIPDelete,
 
@@ -96,7 +97,7 @@ func getFloatingIPSchema(t SchemaType) map[string]*schema.Schema {
 	return m
 }
 
-func resourceFloatingIPCreate(d *schema.ResourceData, meta any) error {
+func resourceFloatingIPCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*cloudscale.Client)
 
 	opts := &cloudscale.FloatingIPCreateRequest{
@@ -129,18 +130,14 @@ func resourceFloatingIPCreate(d *schema.ResourceData, meta any) error {
 
 	log.Printf("[DEBUG] FloatingIP create configuration: %#v", opts)
 
-	floatingIP, err := client.FloatingIPs.Create(context.Background(), opts)
+	floatingIP, err := client.FloatingIPs.Create(ctx, opts)
 	if err != nil {
-		return fmt.Errorf("Error creating FloatingIP: %s", err)
+		return diag.FromErr(fmt.Errorf("Error creating FloatingIP: %s", err))
 	}
 
 	d.SetId(floatingIP.IP())
 
-	err = resourceFloatingIPRead(d, meta)
-	if err != nil {
-		return fmt.Errorf("Error reading the floating IP (%s): %s", d.Id(), err)
-	}
-	return nil
+	return resourceFloatingIPRead(ctx, d, meta)
 }
 
 func gatherFloatingIPResourceData(floatingIP *cloudscale.FloatingIP) ResourceDataRaw {
@@ -171,10 +168,9 @@ func gatherFloatingIPResourceData(floatingIP *cloudscale.FloatingIP) ResourceDat
 	return m
 }
 
-func readFloatingIP(rId GenericResourceIdentifier, meta any) (*cloudscale.FloatingIP, error) {
+func readFloatingIP(ctx context.Context, rId GenericResourceIdentifier, meta any) (*cloudscale.FloatingIP, error) {
 	client := meta.(*cloudscale.Client)
-	return client.FloatingIPs.Get(context.Background(), rId.Id)
-
+	return client.FloatingIPs.Get(ctx, rId.Id)
 }
 
 func updateFloatingIP(ctx context.Context, rId GenericResourceIdentifier, meta any, updateRequest *cloudscale.FloatingIPUpdateRequest) error {

--- a/cloudscale/resource_cloudscale_load_balancer.go
+++ b/cloudscale/resource_cloudscale_load_balancer.go
@@ -22,8 +22,8 @@ func resourceCloudscaleLoadBalancer() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceCloudscaleLoadBalancerCreate,
 		Read:   resourceCloudscaleLoadBalancerRead,
-		Update: resourceCloudscaleLoadBalancerUpdate,
-		Delete: resourceCloudscaleLoadBalancerDelete,
+		UpdateContext: resourceCloudscaleLoadBalancerUpdate,
+		DeleteContext: resourceCloudscaleLoadBalancerDelete,
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -135,7 +135,7 @@ func resourceCloudscaleLoadBalancerCreate(d *schema.ResourceData, meta any) erro
 	log.Printf("[INFO] LoadBalancer ID: %s", d.Id())
 
 	remainingTime := timeout - time.Since(startTime)
-	_, err = waitForStatus([]string{"changing"}, "running", &remainingTime, newLoadBalancerRefreshFunc(d, "status", meta))
+	_, err = waitForStatus(ctx, []string{"changing"}, "running", &remainingTime, newLoadBalancerRefreshFunc(ctx, d, "status", meta))
 	if err != nil {
 		return fmt.Errorf("error waiting for load balancer (%s) to become ready: %s", d.Id(), err)
 	}
@@ -147,13 +147,13 @@ func resourceCloudscaleLoadBalancerCreate(d *schema.ResourceData, meta any) erro
 	return nil
 }
 
-func newLoadBalancerRefreshFunc(d *schema.ResourceData, attribute string, meta any) resource.StateRefreshFunc {
+func newLoadBalancerRefreshFunc(ctx context.Context, d *schema.ResourceData, attribute string, meta any) resource.StateRefreshFunc {
 	client := meta.(*cloudscale.Client)
 	return func() (any, string, error) {
 		id := d.Id()
 
 		// get the instance
-		loadBalancer, err := client.LoadBalancers.Get(context.Background(), id)
+		loadBalancer, err := client.LoadBalancers.Get(ctx, id)
 		if err != nil {
 			return nil, "", fmt.Errorf("error retrieving load balancer(%s) (refresh) %s", id, err)
 		}
@@ -217,9 +217,9 @@ func readLoadBalancer(rId GenericResourceIdentifier, meta any) (*cloudscale.Load
 	return client.LoadBalancers.Get(context.Background(), rId.Id)
 }
 
-func updateLoadBalancer(rId GenericResourceIdentifier, meta any, updateRequest *cloudscale.LoadBalancerRequest) error {
+func updateLoadBalancer(ctx context.Context, rId GenericResourceIdentifier, meta any, updateRequest *cloudscale.LoadBalancerRequest) error {
 	client := meta.(*cloudscale.Client)
-	return client.LoadBalancers.Update(context.Background(), rId.Id, updateRequest)
+	return client.LoadBalancers.Update(ctx, rId.Id, updateRequest)
 }
 
 func gatherLoadBalancerUpdateRequest(d *schema.ResourceData) []*cloudscale.LoadBalancerRequest {
@@ -241,7 +241,7 @@ func gatherLoadBalancerUpdateRequest(d *schema.ResourceData) []*cloudscale.LoadB
 	return requests
 }
 
-func deleteLoadBalancer(rId GenericResourceIdentifier, meta any) error {
+func deleteLoadBalancer(ctx context.Context, rId GenericResourceIdentifier, meta any) error {
 	client := meta.(*cloudscale.Client)
-	return client.LoadBalancers.Delete(context.Background(), rId.Id)
+	return client.LoadBalancers.Delete(ctx, rId.Id)
 }

--- a/cloudscale/resource_cloudscale_load_balancer.go
+++ b/cloudscale/resource_cloudscale_load_balancer.go
@@ -14,6 +14,7 @@ import (
 const loadBalancerHumanName = "load balancer"
 
 var (
+	resourceCloudscaleLoadBalancerCreate = getCreateOperation(createLoadBalancer, nil)
 	resourceCloudscaleLoadBalancerRead   = getReadOperation(loadBalancerHumanName, getGenericResourceIdentifierFromSchema, readLoadBalancer, gatherLoadBalancerResourceData)
 	resourceCloudscaleLoadBalancerUpdate = getUpdateOperation(loadBalancerHumanName, getGenericResourceIdentifierFromSchema, updateLoadBalancer, resourceCloudscaleLoadBalancerRead, gatherLoadBalancerUpdateRequest, nil)
 	resourceCloudscaleLoadBalancerDelete = getDeleteOperation(loadBalancerHumanName, getGenericResourceIdentifierFromSchema, deleteLoadBalancer, nil)
@@ -102,7 +103,7 @@ func getLoadBalancerSchema(t SchemaType) map[string]*schema.Schema {
 	return m
 }
 
-func resourceCloudscaleLoadBalancerCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func createLoadBalancer(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	timeout := d.Timeout(schema.TimeoutCreate)
 	startTime := time.Now()
 

--- a/cloudscale/resource_cloudscale_load_balancer.go
+++ b/cloudscale/resource_cloudscale_load_balancer.go
@@ -14,8 +14,8 @@ const loadBalancerHumanName = "load balancer"
 
 var (
 	resourceCloudscaleLoadBalancerRead   = getReadOperation(loadBalancerHumanName, getGenericResourceIdentifierFromSchema, readLoadBalancer, gatherLoadBalancerResourceData)
-	resourceCloudscaleLoadBalancerUpdate = getUpdateOperation(loadBalancerHumanName, getGenericResourceIdentifierFromSchema, updateLoadBalancer, resourceCloudscaleLoadBalancerRead, gatherLoadBalancerUpdateRequest)
-	resourceCloudscaleLoadBalancerDelete = getDeleteOperation(loadBalancerHumanName, deleteLoadBalancer)
+	resourceCloudscaleLoadBalancerUpdate = getUpdateOperation(loadBalancerHumanName, getGenericResourceIdentifierFromSchema, updateLoadBalancer, resourceCloudscaleLoadBalancerRead, gatherLoadBalancerUpdateRequest, nil)
+	resourceCloudscaleLoadBalancerDelete = getDeleteOperation(loadBalancerHumanName, getGenericResourceIdentifierFromSchema, deleteLoadBalancer, nil)
 )
 
 func resourceCloudscaleLoadBalancer() *schema.Resource {
@@ -241,8 +241,7 @@ func gatherLoadBalancerUpdateRequest(d *schema.ResourceData) []*cloudscale.LoadB
 	return requests
 }
 
-func deleteLoadBalancer(d *schema.ResourceData, meta any) error {
+func deleteLoadBalancer(rId GenericResourceIdentifier, meta any) error {
 	client := meta.(*cloudscale.Client)
-	id := d.Id()
-	return client.LoadBalancers.Delete(context.Background(), id)
+	return client.LoadBalancers.Delete(context.Background(), rId.Id)
 }

--- a/cloudscale/resource_cloudscale_load_balancer.go
+++ b/cloudscale/resource_cloudscale_load_balancer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/cloudscale-ch/cloudscale-go-sdk/v9"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"log"
@@ -20,8 +21,8 @@ var (
 
 func resourceCloudscaleLoadBalancer() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceCloudscaleLoadBalancerCreate,
-		Read:   resourceCloudscaleLoadBalancerRead,
+		CreateContext: resourceCloudscaleLoadBalancerCreate,
+		ReadContext:   resourceCloudscaleLoadBalancerRead,
 		UpdateContext: resourceCloudscaleLoadBalancerUpdate,
 		DeleteContext: resourceCloudscaleLoadBalancerDelete,
 
@@ -101,7 +102,7 @@ func getLoadBalancerSchema(t SchemaType) map[string]*schema.Schema {
 	return m
 }
 
-func resourceCloudscaleLoadBalancerCreate(d *schema.ResourceData, meta any) error {
+func resourceCloudscaleLoadBalancerCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	timeout := d.Timeout(schema.TimeoutCreate)
 	startTime := time.Now()
 
@@ -125,9 +126,9 @@ func resourceCloudscaleLoadBalancerCreate(d *schema.ResourceData, meta any) erro
 
 	log.Printf("[DEBUG] LoadBalancer create configuration: %#v", opts)
 
-	loadbalancer, err := client.LoadBalancers.Create(context.Background(), opts)
+	loadbalancer, err := client.LoadBalancers.Create(ctx, opts)
 	if err != nil {
-		return fmt.Errorf("Error creating LoadBalancer: %s", err)
+		return diag.FromErr(fmt.Errorf("Error creating LoadBalancer: %s", err))
 	}
 
 	d.SetId(loadbalancer.UUID)
@@ -137,14 +138,10 @@ func resourceCloudscaleLoadBalancerCreate(d *schema.ResourceData, meta any) erro
 	remainingTime := timeout - time.Since(startTime)
 	_, err = waitForStatus(ctx, []string{"changing"}, "running", &remainingTime, newLoadBalancerRefreshFunc(ctx, d, "status", meta))
 	if err != nil {
-		return fmt.Errorf("error waiting for load balancer (%s) to become ready: %s", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("error waiting for load balancer (%s) to become ready: %s", d.Id(), err))
 	}
 
-	err = resourceCloudscaleLoadBalancerRead(d, meta)
-	if err != nil {
-		return fmt.Errorf("error reading the load balancer (%s): %s", d.Id(), err)
-	}
-	return nil
+	return resourceCloudscaleLoadBalancerRead(ctx, d, meta)
 }
 
 func newLoadBalancerRefreshFunc(ctx context.Context, d *schema.ResourceData, attribute string, meta any) resource.StateRefreshFunc {
@@ -212,9 +209,9 @@ func gatherLoadBalancerResourceData(loadbalancer *cloudscale.LoadBalancer) Resou
 	return m
 }
 
-func readLoadBalancer(rId GenericResourceIdentifier, meta any) (*cloudscale.LoadBalancer, error) {
+func readLoadBalancer(ctx context.Context, rId GenericResourceIdentifier, meta any) (*cloudscale.LoadBalancer, error) {
 	client := meta.(*cloudscale.Client)
-	return client.LoadBalancers.Get(context.Background(), rId.Id)
+	return client.LoadBalancers.Get(ctx, rId.Id)
 }
 
 func updateLoadBalancer(ctx context.Context, rId GenericResourceIdentifier, meta any, updateRequest *cloudscale.LoadBalancerRequest) error {

--- a/cloudscale/resource_cloudscale_load_balancer_health_monitor.go
+++ b/cloudscale/resource_cloudscale_load_balancer_health_monitor.go
@@ -12,8 +12,8 @@ const healthMonitorHumanName = "load balancer health monitor"
 
 var (
 	resourceCloudscaleLoadBalancerHealthMonitorRead   = getReadOperation(healthMonitorHumanName, getGenericResourceIdentifierFromSchema, readLoadBalancerHealthMonitor, gatherLoadBalancerHealthMonitorResourceData)
-	resourceCloudscaleLoadBalancerHealthMonitorUpdate = getUpdateOperation(healthMonitorHumanName, getGenericResourceIdentifierFromSchema, updateLoadBalancerHealthMonitor, resourceCloudscaleLoadBalancerHealthMonitorRead, gatherLoadBalancerHealthMonitorUpdateRequests)
-	resourceCloudscaleLoadBalancerHealthMonitorDelete = getDeleteOperation(healthMonitorHumanName, deleteLoadBalancerHealthMonitor)
+	resourceCloudscaleLoadBalancerHealthMonitorUpdate = getUpdateOperation(healthMonitorHumanName, getGenericResourceIdentifierFromSchema, updateLoadBalancerHealthMonitor, resourceCloudscaleLoadBalancerHealthMonitorRead, gatherLoadBalancerHealthMonitorUpdateRequests, nil)
+	resourceCloudscaleLoadBalancerHealthMonitorDelete = getDeleteOperation(healthMonitorHumanName, getGenericResourceIdentifierFromSchema, deleteLoadBalancerHealthMonitor, nil)
 )
 
 func resourceCloudscaleLoadBalancerHealthMonitor() *schema.Resource {
@@ -274,8 +274,7 @@ func gatherLoadBalancerHealthMonitorResourceData(loadBalancerHealthMonitor *clou
 	return m
 }
 
-func deleteLoadBalancerHealthMonitor(d *schema.ResourceData, meta any) error {
+func deleteLoadBalancerHealthMonitor(rId GenericResourceIdentifier, meta any) error {
 	client := meta.(*cloudscale.Client)
-	id := d.Id()
-	return client.LoadBalancerHealthMonitors.Delete(context.Background(), id)
+	return client.LoadBalancerHealthMonitors.Delete(context.Background(), rId.Id)
 }

--- a/cloudscale/resource_cloudscale_load_balancer_health_monitor.go
+++ b/cloudscale/resource_cloudscale_load_balancer_health_monitor.go
@@ -12,18 +12,17 @@ import (
 
 const healthMonitorHumanName = "load balancer health monitor"
 
+// Health monitor operations serialize on the load balancer that owns the parent pool
+// via lockKeyFromPoolUUID.
 var (
-	resourceCloudscaleLoadBalancerHealthMonitorCreate = getCreateOperation(createLoadBalancerHealthMonitor, nil)
+	resourceCloudscaleLoadBalancerHealthMonitorCreate = getCreateOperation(createLoadBalancerHealthMonitor, lockKeyFromPoolUUID)
 	resourceCloudscaleLoadBalancerHealthMonitorRead   = getReadOperation(healthMonitorHumanName, getGenericResourceIdentifierFromSchema, readLoadBalancerHealthMonitor, gatherLoadBalancerHealthMonitorResourceData)
-	resourceCloudscaleLoadBalancerHealthMonitorUpdate = getUpdateOperation(healthMonitorHumanName, getGenericResourceIdentifierFromSchema, updateLoadBalancerHealthMonitor, resourceCloudscaleLoadBalancerHealthMonitorRead, gatherLoadBalancerHealthMonitorUpdateRequests, nil)
-	resourceCloudscaleLoadBalancerHealthMonitorDelete = getDeleteOperation(healthMonitorHumanName, getGenericResourceIdentifierFromSchema, deleteLoadBalancerHealthMonitor, nil)
+	resourceCloudscaleLoadBalancerHealthMonitorUpdate = getUpdateOperation(healthMonitorHumanName, getGenericResourceIdentifierFromSchema, updateLoadBalancerHealthMonitor, resourceCloudscaleLoadBalancerHealthMonitorRead, gatherLoadBalancerHealthMonitorUpdateRequests, lockKeyFromPoolUUID)
+	resourceCloudscaleLoadBalancerHealthMonitorDelete = getDeleteOperation(healthMonitorHumanName, getGenericResourceIdentifierFromSchema, deleteLoadBalancerHealthMonitor, lockKeyFromPoolUUID)
 )
 
 func resourceCloudscaleLoadBalancerHealthMonitor() *schema.Resource {
 	return &schema.Resource{
-		// Unlike pools, pool members and listeners, health monitor operations are not
-		// serialized: only one health monitor per pool is allowed,
-		// so a mutex would never actually serialize anything.
 		CreateContext: resourceCloudscaleLoadBalancerHealthMonitorCreate,
 		ReadContext:   resourceCloudscaleLoadBalancerHealthMonitorRead,
 		UpdateContext: resourceCloudscaleLoadBalancerHealthMonitorUpdate,

--- a/cloudscale/resource_cloudscale_load_balancer_health_monitor.go
+++ b/cloudscale/resource_cloudscale_load_balancer_health_monitor.go
@@ -3,9 +3,11 @@ package cloudscale
 import (
 	"context"
 	"fmt"
-	"github.com/cloudscale-ch/cloudscale-go-sdk/v9"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"log"
+
+	"github.com/cloudscale-ch/cloudscale-go-sdk/v9"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 const healthMonitorHumanName = "load balancer health monitor"
@@ -21,10 +23,10 @@ func resourceCloudscaleLoadBalancerHealthMonitor() *schema.Resource {
 		// Unlike pools, pool members and listeners, health monitor operations are not
 		// wrapped with withLock: only one health monitor per pool is allowed, so a
 		// mutex would never actually serialize anything.
-		Create: resourceCloudscaleLoadBalancerHealthMonitorCreate,
-		Read:   resourceCloudscaleLoadBalancerHealthMonitorRead,
-		Update: resourceCloudscaleLoadBalancerHealthMonitorUpdate,
-		Delete: resourceCloudscaleLoadBalancerHealthMonitorDelete,
+		CreateContext: resourceCloudscaleLoadBalancerHealthMonitorCreate,
+		Read:          resourceCloudscaleLoadBalancerHealthMonitorRead,
+		UpdateContext: resourceCloudscaleLoadBalancerHealthMonitorUpdate,
+		DeleteContext: resourceCloudscaleLoadBalancerHealthMonitorDelete,
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -117,7 +119,7 @@ func getLoadBalancerHealthMonitorSchema(t SchemaType) map[string]*schema.Schema 
 	return m
 }
 
-func resourceCloudscaleLoadBalancerHealthMonitorCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCloudscaleLoadBalancerHealthMonitorCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudscale.Client)
 
 	opts := &cloudscale.LoadBalancerHealthMonitorRequest{
@@ -165,19 +167,15 @@ func resourceCloudscaleLoadBalancerHealthMonitorCreate(d *schema.ResourceData, m
 
 	log.Printf("[DEBUG] LoadBalancerHealthMonitor create configuration: %#v", opts)
 
-	healthMonitor, err := client.LoadBalancerHealthMonitors.Create(context.Background(), opts)
+	healthMonitor, err := client.LoadBalancerHealthMonitors.Create(ctx, opts)
 	if err != nil {
-		return fmt.Errorf("error creating LoadBalancerHealthMonitor: %s", err)
+		return diag.FromErr(fmt.Errorf("error creating LoadBalancerHealthMonitor: %s", err))
 	}
 
 	d.SetId(healthMonitor.UUID)
 
 	log.Printf("[INFO] LoadBalancerHealthMonitor UUID: %s", d.Id())
-	err = resourceCloudscaleLoadBalancerHealthMonitorRead(d, meta)
-	if err != nil {
-		return fmt.Errorf("error reading the load balancer health monitor (%s): %s", d.Id(), err)
-	}
-	return nil
+	return diag.FromErr(resourceCloudscaleLoadBalancerHealthMonitorRead(d, meta))
 }
 
 func getCodes(codes []any) []string {
@@ -193,9 +191,9 @@ func readLoadBalancerHealthMonitor(rId GenericResourceIdentifier, meta any) (*cl
 	return client.LoadBalancerHealthMonitors.Get(context.Background(), rId.Id)
 }
 
-func updateLoadBalancerHealthMonitor(rId GenericResourceIdentifier, meta any, updateRequest *cloudscale.LoadBalancerHealthMonitorRequest) error {
+func updateLoadBalancerHealthMonitor(ctx context.Context, rId GenericResourceIdentifier, meta any, updateRequest *cloudscale.LoadBalancerHealthMonitorRequest) error {
 	client := meta.(*cloudscale.Client)
-	return client.LoadBalancerHealthMonitors.Update(context.Background(), rId.Id, updateRequest)
+	return client.LoadBalancerHealthMonitors.Update(ctx, rId.Id, updateRequest)
 }
 
 func gatherLoadBalancerHealthMonitorUpdateRequests(d *schema.ResourceData) []*cloudscale.LoadBalancerHealthMonitorRequest {
@@ -235,7 +233,7 @@ func gatherLoadBalancerHealthMonitorUpdateRequests(d *schema.ResourceData) []*cl
 					httpOpts.Method = d.Get(attribute).(string)
 				} else if attribute == "http_url_path" {
 					httpOpts.UrlPath = d.Get(attribute).(string)
-				}else if attribute == "http_host" {
+				} else if attribute == "http_host" {
 					if attr, ok := d.GetOk(attribute); ok {
 						s := attr.(string)
 						httpOpts.Host = &s
@@ -274,7 +272,7 @@ func gatherLoadBalancerHealthMonitorResourceData(loadBalancerHealthMonitor *clou
 	return m
 }
 
-func deleteLoadBalancerHealthMonitor(rId GenericResourceIdentifier, meta any) error {
+func deleteLoadBalancerHealthMonitor(ctx context.Context, rId GenericResourceIdentifier, meta any) error {
 	client := meta.(*cloudscale.Client)
-	return client.LoadBalancerHealthMonitors.Delete(context.Background(), rId.Id)
+	return client.LoadBalancerHealthMonitors.Delete(ctx, rId.Id)
 }

--- a/cloudscale/resource_cloudscale_load_balancer_health_monitor.go
+++ b/cloudscale/resource_cloudscale_load_balancer_health_monitor.go
@@ -13,6 +13,7 @@ import (
 const healthMonitorHumanName = "load balancer health monitor"
 
 var (
+	resourceCloudscaleLoadBalancerHealthMonitorCreate = getCreateOperation(createLoadBalancerHealthMonitor, nil)
 	resourceCloudscaleLoadBalancerHealthMonitorRead   = getReadOperation(healthMonitorHumanName, getGenericResourceIdentifierFromSchema, readLoadBalancerHealthMonitor, gatherLoadBalancerHealthMonitorResourceData)
 	resourceCloudscaleLoadBalancerHealthMonitorUpdate = getUpdateOperation(healthMonitorHumanName, getGenericResourceIdentifierFromSchema, updateLoadBalancerHealthMonitor, resourceCloudscaleLoadBalancerHealthMonitorRead, gatherLoadBalancerHealthMonitorUpdateRequests, nil)
 	resourceCloudscaleLoadBalancerHealthMonitorDelete = getDeleteOperation(healthMonitorHumanName, getGenericResourceIdentifierFromSchema, deleteLoadBalancerHealthMonitor, nil)
@@ -21,8 +22,8 @@ var (
 func resourceCloudscaleLoadBalancerHealthMonitor() *schema.Resource {
 	return &schema.Resource{
 		// Unlike pools, pool members and listeners, health monitor operations are not
-		// wrapped with withLock: only one health monitor per pool is allowed, so a
-		// mutex would never actually serialize anything.
+		// serialized: only one health monitor per pool is allowed,
+		// so a mutex would never actually serialize anything.
 		CreateContext: resourceCloudscaleLoadBalancerHealthMonitorCreate,
 		ReadContext:   resourceCloudscaleLoadBalancerHealthMonitorRead,
 		UpdateContext: resourceCloudscaleLoadBalancerHealthMonitorUpdate,
@@ -119,7 +120,7 @@ func getLoadBalancerHealthMonitorSchema(t SchemaType) map[string]*schema.Schema 
 	return m
 }
 
-func resourceCloudscaleLoadBalancerHealthMonitorCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func createLoadBalancerHealthMonitor(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudscale.Client)
 
 	opts := &cloudscale.LoadBalancerHealthMonitorRequest{

--- a/cloudscale/resource_cloudscale_load_balancer_health_monitor.go
+++ b/cloudscale/resource_cloudscale_load_balancer_health_monitor.go
@@ -24,7 +24,7 @@ func resourceCloudscaleLoadBalancerHealthMonitor() *schema.Resource {
 		// wrapped with withLock: only one health monitor per pool is allowed, so a
 		// mutex would never actually serialize anything.
 		CreateContext: resourceCloudscaleLoadBalancerHealthMonitorCreate,
-		Read:          resourceCloudscaleLoadBalancerHealthMonitorRead,
+		ReadContext:   resourceCloudscaleLoadBalancerHealthMonitorRead,
 		UpdateContext: resourceCloudscaleLoadBalancerHealthMonitorUpdate,
 		DeleteContext: resourceCloudscaleLoadBalancerHealthMonitorDelete,
 
@@ -175,7 +175,7 @@ func resourceCloudscaleLoadBalancerHealthMonitorCreate(ctx context.Context, d *s
 	d.SetId(healthMonitor.UUID)
 
 	log.Printf("[INFO] LoadBalancerHealthMonitor UUID: %s", d.Id())
-	return diag.FromErr(resourceCloudscaleLoadBalancerHealthMonitorRead(d, meta))
+	return resourceCloudscaleLoadBalancerHealthMonitorRead(ctx, d, meta)
 }
 
 func getCodes(codes []any) []string {
@@ -186,9 +186,9 @@ func getCodes(codes []any) []string {
 	return s
 }
 
-func readLoadBalancerHealthMonitor(rId GenericResourceIdentifier, meta any) (*cloudscale.LoadBalancerHealthMonitor, error) {
+func readLoadBalancerHealthMonitor(ctx context.Context, rId GenericResourceIdentifier, meta any) (*cloudscale.LoadBalancerHealthMonitor, error) {
 	client := meta.(*cloudscale.Client)
-	return client.LoadBalancerHealthMonitors.Get(context.Background(), rId.Id)
+	return client.LoadBalancerHealthMonitors.Get(ctx, rId.Id)
 }
 
 func updateLoadBalancerHealthMonitor(ctx context.Context, rId GenericResourceIdentifier, meta any, updateRequest *cloudscale.LoadBalancerHealthMonitorRequest) error {

--- a/cloudscale/resource_cloudscale_load_balancer_health_monitor.go
+++ b/cloudscale/resource_cloudscale_load_balancer_health_monitor.go
@@ -18,6 +18,9 @@ var (
 
 func resourceCloudscaleLoadBalancerHealthMonitor() *schema.Resource {
 	return &schema.Resource{
+		// Unlike pools, pool members and listeners, health monitor operations are not
+		// wrapped with withLock: only one health monitor per pool is allowed, so a
+		// mutex would never actually serialize anything.
 		Create: resourceCloudscaleLoadBalancerHealthMonitorCreate,
 		Read:   resourceCloudscaleLoadBalancerHealthMonitorRead,
 		Update: resourceCloudscaleLoadBalancerHealthMonitorUpdate,
@@ -117,10 +120,8 @@ func getLoadBalancerHealthMonitorSchema(t SchemaType) map[string]*schema.Schema 
 func resourceCloudscaleLoadBalancerHealthMonitorCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudscale.Client)
 
-	// No mutex needed: only one health monitor per pool is allowed, so a mutex would never actually serialize anything.
-	poolUUID := d.Get("pool_uuid").(string)
 	opts := &cloudscale.LoadBalancerHealthMonitorRequest{
-		Pool: poolUUID,
+		Pool: d.Get("pool_uuid").(string),
 		Type: d.Get("type").(string),
 	}
 
@@ -274,7 +275,6 @@ func gatherLoadBalancerHealthMonitorResourceData(loadBalancerHealthMonitor *clou
 }
 
 func deleteLoadBalancerHealthMonitor(d *schema.ResourceData, meta any) error {
-	// No mutex needed: only one health monitor per pool is allowed, so a mutex would never actually serialize anything.
 	client := meta.(*cloudscale.Client)
 	id := d.Id()
 	return client.LoadBalancerHealthMonitors.Delete(context.Background(), id)

--- a/cloudscale/resource_cloudscale_load_balancer_health_monitor.go
+++ b/cloudscale/resource_cloudscale_load_balancer_health_monitor.go
@@ -117,8 +117,10 @@ func getLoadBalancerHealthMonitorSchema(t SchemaType) map[string]*schema.Schema 
 func resourceCloudscaleLoadBalancerHealthMonitorCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*cloudscale.Client)
 
+	// No mutex needed: only one health monitor per pool is allowed, so a mutex would never actually serialize anything.
+	poolUUID := d.Get("pool_uuid").(string)
 	opts := &cloudscale.LoadBalancerHealthMonitorRequest{
-		Pool: d.Get("pool_uuid").(string),
+		Pool: poolUUID,
 		Type: d.Get("type").(string),
 	}
 
@@ -272,6 +274,7 @@ func gatherLoadBalancerHealthMonitorResourceData(loadBalancerHealthMonitor *clou
 }
 
 func deleteLoadBalancerHealthMonitor(d *schema.ResourceData, meta any) error {
+	// No mutex needed: only one health monitor per pool is allowed, so a mutex would never actually serialize anything.
 	client := meta.(*cloudscale.Client)
 	id := d.Id()
 	return client.LoadBalancerHealthMonitors.Delete(context.Background(), id)

--- a/cloudscale/resource_cloudscale_load_balancer_listener.go
+++ b/cloudscale/resource_cloudscale_load_balancer_listener.go
@@ -12,21 +12,15 @@ import (
 
 const listenerHumanName = "load balancer listener"
 
-// loadBalancerListenerLockKey serializes listener operations on their parent pool when
-// one is set. If the API ever supports pool-less listeners, we will also need to lock on
-// the LB UUID to serialize those.
-func loadBalancerListenerLockKey(d *schema.ResourceData) (string, bool) {
-	if poolUUID, ok := d.GetOk("pool_uuid"); ok {
-		return lbPoolLockKey(poolUUID.(string)), true
-	}
-	return "", false
-}
-
+// Listener operations serialize on the load balancer that owns the parent pool
+// via lockKeyFromPoolUUID. The API requires a pool on every listener today, so the
+// unlocked path is unreachable. When pool-less listeners land, the listener gains an
+// optional load_balancer_uuid (mutually exclusive with pool_uuid) to lock on instead.
 var (
-	resourceCloudscaleLoadBalancerListenerCreate = getCreateOperation(createLoadBalancerListener, loadBalancerListenerLockKey)
+	resourceCloudscaleLoadBalancerListenerCreate = getCreateOperation(createLoadBalancerListener, lockKeyFromPoolUUID)
 	resourceCloudscaleLoadBalancerListenerRead   = getReadOperation(listenerHumanName, getGenericResourceIdentifierFromSchema, readLoadBalancerListener, gatherLoadBalancerListenerResourceData)
-	resourceCloudscaleLoadBalancerListenerUpdate = getUpdateOperation(listenerHumanName, getGenericResourceIdentifierFromSchema, updateLoadBalancerListener, resourceCloudscaleLoadBalancerListenerRead, gatherLoadBalancerListenerUpdateRequest, loadBalancerListenerLockKey)
-	resourceCloudscaleLoadBalancerListenerDelete = getDeleteOperation(listenerHumanName, getGenericResourceIdentifierFromSchema, deleteLoadBalancerListener, loadBalancerListenerLockKey)
+	resourceCloudscaleLoadBalancerListenerUpdate = getUpdateOperation(listenerHumanName, getGenericResourceIdentifierFromSchema, updateLoadBalancerListener, resourceCloudscaleLoadBalancerListenerRead, gatherLoadBalancerListenerUpdateRequest, lockKeyFromPoolUUID)
+	resourceCloudscaleLoadBalancerListenerDelete = getDeleteOperation(listenerHumanName, getGenericResourceIdentifierFromSchema, deleteLoadBalancerListener, lockKeyFromPoolUUID)
 )
 
 func resourceCloudscaleLoadBalancerListener() *schema.Resource {

--- a/cloudscale/resource_cloudscale_load_balancer_listener.go
+++ b/cloudscale/resource_cloudscale_load_balancer_listener.go
@@ -101,14 +101,22 @@ func getLoadBalancerListenerSchema(t SchemaType) map[string]*schema.Schema {
 func resourceCloudscaleLoadBalancerListenerCreate(d *schema.ResourceData, meta any) error {
 	client := meta.(*cloudscale.Client)
 
+	// Lock on the pool when present. If the API ever supports pool-less listeners,
+	// we will also need to lock on the LB UUID to serialize those.
+	poolUUID, hasPool := d.GetOk("pool_uuid")
+	if hasPool {
+		globalMu.Lock(lbPoolLockKey(poolUUID.(string)))
+		defer globalMu.Unlock(lbPoolLockKey(poolUUID.(string)))
+	}
+
 	opts := &cloudscale.LoadBalancerListenerRequest{
 		Name:         d.Get("name").(string),
 		Protocol:     d.Get("protocol").(string),
 		ProtocolPort: d.Get("protocol_port").(int),
 	}
 
-	if attr, ok := d.GetOk("pool_uuid"); ok {
-		opts.Pool = attr.(string)
+	if hasPool {
+		opts.Pool = poolUUID.(string)
 	}
 
 	if attr, ok := d.GetOk("timeout_client_data_ms"); ok {
@@ -225,5 +233,11 @@ func gatherLoadBalancerListenerUpdateRequest(d *schema.ResourceData) []*cloudsca
 func deleteLoadBalancerListener(d *schema.ResourceData, meta any) error {
 	client := meta.(*cloudscale.Client)
 	id := d.Id()
+	// Lock on the pool when present. If the API ever supports pool-less listeners,
+	// we will also need to lock on the LB UUID to serialize those.
+	if poolUUID, ok := d.GetOk("pool_uuid"); ok {
+		globalMu.Lock(lbPoolLockKey(poolUUID.(string)))
+		defer globalMu.Unlock(lbPoolLockKey(poolUUID.(string)))
+	}
 	return client.LoadBalancerListeners.Delete(context.Background(), id)
 }

--- a/cloudscale/resource_cloudscale_load_balancer_listener.go
+++ b/cloudscale/resource_cloudscale_load_balancer_listener.go
@@ -23,16 +23,16 @@ func loadBalancerListenerLockKey(d *schema.ResourceData) (string, bool) {
 
 var (
 	resourceCloudscaleLoadBalancerListenerRead   = getReadOperation(listenerHumanName, getGenericResourceIdentifierFromSchema, readLoadBalancerListener, gatherLoadBalancerListenerResourceData)
-	resourceCloudscaleLoadBalancerListenerUpdate = getUpdateOperation(listenerHumanName, getGenericResourceIdentifierFromSchema, updateLoadBalancerListener, resourceCloudscaleLoadBalancerListenerRead, gatherLoadBalancerListenerUpdateRequest)
-	resourceCloudscaleLoadBalancerListenerDelete = getDeleteOperation(listenerHumanName, deleteLoadBalancerListener)
+	resourceCloudscaleLoadBalancerListenerUpdate = getUpdateOperation(listenerHumanName, getGenericResourceIdentifierFromSchema, updateLoadBalancerListener, resourceCloudscaleLoadBalancerListenerRead, gatherLoadBalancerListenerUpdateRequest, loadBalancerListenerLockKey)
+	resourceCloudscaleLoadBalancerListenerDelete = getDeleteOperation(listenerHumanName, getGenericResourceIdentifierFromSchema, deleteLoadBalancerListener, loadBalancerListenerLockKey)
 )
 
 func resourceCloudscaleLoadBalancerListener() *schema.Resource {
 	return &schema.Resource{
 		Create: withLock(loadBalancerListenerLockKey, resourceCloudscaleLoadBalancerListenerCreate),
 		Read:   resourceCloudscaleLoadBalancerListenerRead,
-		Update: withLock(loadBalancerListenerLockKey, resourceCloudscaleLoadBalancerListenerUpdate),
-		Delete: withLock(loadBalancerListenerLockKey, resourceCloudscaleLoadBalancerListenerDelete),
+		Update: resourceCloudscaleLoadBalancerListenerUpdate,
+		Delete: resourceCloudscaleLoadBalancerListenerDelete,
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -232,8 +232,7 @@ func gatherLoadBalancerListenerUpdateRequest(d *schema.ResourceData) []*cloudsca
 	return requests
 }
 
-func deleteLoadBalancerListener(d *schema.ResourceData, meta any) error {
+func deleteLoadBalancerListener(rId GenericResourceIdentifier, meta any) error {
 	client := meta.(*cloudscale.Client)
-	id := d.Id()
-	return client.LoadBalancerListeners.Delete(context.Background(), id)
+	return client.LoadBalancerListeners.Delete(context.Background(), rId.Id)
 }

--- a/cloudscale/resource_cloudscale_load_balancer_listener.go
+++ b/cloudscale/resource_cloudscale_load_balancer_listener.go
@@ -6,6 +6,7 @@ import (
 	"log"
 
 	"github.com/cloudscale-ch/cloudscale-go-sdk/v9"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -29,10 +30,10 @@ var (
 
 func resourceCloudscaleLoadBalancerListener() *schema.Resource {
 	return &schema.Resource{
-		Create: withLock(loadBalancerListenerLockKey, resourceCloudscaleLoadBalancerListenerCreate),
-		Read:   resourceCloudscaleLoadBalancerListenerRead,
-		Update: resourceCloudscaleLoadBalancerListenerUpdate,
-		Delete: resourceCloudscaleLoadBalancerListenerDelete,
+		CreateContext: withLock(loadBalancerListenerLockKey, resourceCloudscaleLoadBalancerListenerCreate),
+		Read:          resourceCloudscaleLoadBalancerListenerRead,
+		UpdateContext: resourceCloudscaleLoadBalancerListenerUpdate,
+		DeleteContext: resourceCloudscaleLoadBalancerListenerDelete,
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -108,7 +109,7 @@ func getLoadBalancerListenerSchema(t SchemaType) map[string]*schema.Schema {
 	return m
 }
 
-func resourceCloudscaleLoadBalancerListenerCreate(d *schema.ResourceData, meta any) error {
+func resourceCloudscaleLoadBalancerListenerCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudscale.Client)
 
 	opts := &cloudscale.LoadBalancerListenerRequest{
@@ -142,19 +143,15 @@ func resourceCloudscaleLoadBalancerListenerCreate(d *schema.ResourceData, meta a
 
 	log.Printf("[DEBUG] LoadBalancerListener create configuration: %#v", opts)
 
-	loadBalancerListener, err := client.LoadBalancerListeners.Create(context.Background(), opts)
+	loadBalancerListener, err := client.LoadBalancerListeners.Create(ctx, opts)
 	if err != nil {
-		return fmt.Errorf("Error creating LoadBalancerListener: %s", err)
+		return diag.FromErr(fmt.Errorf("Error creating LoadBalancerListener: %s", err))
 	}
 
 	d.SetId(loadBalancerListener.UUID)
 
 	log.Printf("[INFO] LoadBalancerListener ID: %s", d.Id())
-	err = resourceCloudscaleLoadBalancerListenerRead(d, meta)
-	if err != nil {
-		return fmt.Errorf("Error reading the load balancer listener (%s): %s", d.Id(), err)
-	}
-	return nil
+	return diag.FromErr(resourceCloudscaleLoadBalancerListenerRead(d, meta))
 }
 
 func gatherLoadBalancerListenerResourceData(loadbalancerlistener *cloudscale.LoadBalancerListener) ResourceDataRaw {
@@ -186,9 +183,9 @@ func readLoadBalancerListener(rId GenericResourceIdentifier, meta any) (*cloudsc
 	return client.LoadBalancerListeners.Get(context.Background(), rId.Id)
 }
 
-func updateLoadBalancerListener(rId GenericResourceIdentifier, meta any, updateRequest *cloudscale.LoadBalancerListenerRequest) error {
+func updateLoadBalancerListener(ctx context.Context, rId GenericResourceIdentifier, meta any, updateRequest *cloudscale.LoadBalancerListenerRequest) error {
 	client := meta.(*cloudscale.Client)
-	return client.LoadBalancerListeners.Update(context.Background(), rId.Id, updateRequest)
+	return client.LoadBalancerListeners.Update(ctx, rId.Id, updateRequest)
 }
 
 func gatherLoadBalancerListenerUpdateRequest(d *schema.ResourceData) []*cloudscale.LoadBalancerListenerRequest {
@@ -232,7 +229,7 @@ func gatherLoadBalancerListenerUpdateRequest(d *schema.ResourceData) []*cloudsca
 	return requests
 }
 
-func deleteLoadBalancerListener(rId GenericResourceIdentifier, meta any) error {
+func deleteLoadBalancerListener(ctx context.Context, rId GenericResourceIdentifier, meta any) error {
 	client := meta.(*cloudscale.Client)
-	return client.LoadBalancerListeners.Delete(context.Background(), rId.Id)
+	return client.LoadBalancerListeners.Delete(ctx, rId.Id)
 }

--- a/cloudscale/resource_cloudscale_load_balancer_listener.go
+++ b/cloudscale/resource_cloudscale_load_balancer_listener.go
@@ -31,7 +31,7 @@ var (
 func resourceCloudscaleLoadBalancerListener() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: withLock(loadBalancerListenerLockKey, resourceCloudscaleLoadBalancerListenerCreate),
-		Read:          resourceCloudscaleLoadBalancerListenerRead,
+		ReadContext:   resourceCloudscaleLoadBalancerListenerRead,
 		UpdateContext: resourceCloudscaleLoadBalancerListenerUpdate,
 		DeleteContext: resourceCloudscaleLoadBalancerListenerDelete,
 
@@ -151,7 +151,7 @@ func resourceCloudscaleLoadBalancerListenerCreate(ctx context.Context, d *schema
 	d.SetId(loadBalancerListener.UUID)
 
 	log.Printf("[INFO] LoadBalancerListener ID: %s", d.Id())
-	return diag.FromErr(resourceCloudscaleLoadBalancerListenerRead(d, meta))
+	return resourceCloudscaleLoadBalancerListenerRead(ctx, d, meta)
 }
 
 func gatherLoadBalancerListenerResourceData(loadbalancerlistener *cloudscale.LoadBalancerListener) ResourceDataRaw {
@@ -178,9 +178,9 @@ func gatherLoadBalancerListenerResourceData(loadbalancerlistener *cloudscale.Loa
 	return m
 }
 
-func readLoadBalancerListener(rId GenericResourceIdentifier, meta any) (*cloudscale.LoadBalancerListener, error) {
+func readLoadBalancerListener(ctx context.Context, rId GenericResourceIdentifier, meta any) (*cloudscale.LoadBalancerListener, error) {
 	client := meta.(*cloudscale.Client)
-	return client.LoadBalancerListeners.Get(context.Background(), rId.Id)
+	return client.LoadBalancerListeners.Get(ctx, rId.Id)
 }
 
 func updateLoadBalancerListener(ctx context.Context, rId GenericResourceIdentifier, meta any, updateRequest *cloudscale.LoadBalancerListenerRequest) error {

--- a/cloudscale/resource_cloudscale_load_balancer_listener.go
+++ b/cloudscale/resource_cloudscale_load_balancer_listener.go
@@ -11,6 +11,16 @@ import (
 
 const listenerHumanName = "load balancer listener"
 
+// loadBalancerListenerLockKey serializes listener operations on their parent pool when
+// one is set. If the API ever supports pool-less listeners, we will also need to lock on
+// the LB UUID to serialize those.
+func loadBalancerListenerLockKey(d *schema.ResourceData) (string, bool) {
+	if poolUUID, ok := d.GetOk("pool_uuid"); ok {
+		return lbPoolLockKey(poolUUID.(string)), true
+	}
+	return "", false
+}
+
 var (
 	resourceCloudscaleLoadBalancerListenerRead   = getReadOperation(listenerHumanName, getGenericResourceIdentifierFromSchema, readLoadBalancerListener, gatherLoadBalancerListenerResourceData)
 	resourceCloudscaleLoadBalancerListenerUpdate = getUpdateOperation(listenerHumanName, getGenericResourceIdentifierFromSchema, updateLoadBalancerListener, resourceCloudscaleLoadBalancerListenerRead, gatherLoadBalancerListenerUpdateRequest)
@@ -19,10 +29,10 @@ var (
 
 func resourceCloudscaleLoadBalancerListener() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceCloudscaleLoadBalancerListenerCreate,
+		Create: withLock(loadBalancerListenerLockKey, resourceCloudscaleLoadBalancerListenerCreate),
 		Read:   resourceCloudscaleLoadBalancerListenerRead,
-		Update: resourceCloudscaleLoadBalancerListenerUpdate,
-		Delete: resourceCloudscaleLoadBalancerListenerDelete,
+		Update: withLock(loadBalancerListenerLockKey, resourceCloudscaleLoadBalancerListenerUpdate),
+		Delete: withLock(loadBalancerListenerLockKey, resourceCloudscaleLoadBalancerListenerDelete),
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -101,22 +111,14 @@ func getLoadBalancerListenerSchema(t SchemaType) map[string]*schema.Schema {
 func resourceCloudscaleLoadBalancerListenerCreate(d *schema.ResourceData, meta any) error {
 	client := meta.(*cloudscale.Client)
 
-	// Lock on the pool when present. If the API ever supports pool-less listeners,
-	// we will also need to lock on the LB UUID to serialize those.
-	poolUUID, hasPool := d.GetOk("pool_uuid")
-	if hasPool {
-		globalMu.Lock(lbPoolLockKey(poolUUID.(string)))
-		defer globalMu.Unlock(lbPoolLockKey(poolUUID.(string)))
-	}
-
 	opts := &cloudscale.LoadBalancerListenerRequest{
 		Name:         d.Get("name").(string),
 		Protocol:     d.Get("protocol").(string),
 		ProtocolPort: d.Get("protocol_port").(int),
 	}
 
-	if hasPool {
-		opts.Pool = poolUUID.(string)
+	if attr, ok := d.GetOk("pool_uuid"); ok {
+		opts.Pool = attr.(string)
 	}
 
 	if attr, ok := d.GetOk("timeout_client_data_ms"); ok {
@@ -233,11 +235,5 @@ func gatherLoadBalancerListenerUpdateRequest(d *schema.ResourceData) []*cloudsca
 func deleteLoadBalancerListener(d *schema.ResourceData, meta any) error {
 	client := meta.(*cloudscale.Client)
 	id := d.Id()
-	// Lock on the pool when present. If the API ever supports pool-less listeners,
-	// we will also need to lock on the LB UUID to serialize those.
-	if poolUUID, ok := d.GetOk("pool_uuid"); ok {
-		globalMu.Lock(lbPoolLockKey(poolUUID.(string)))
-		defer globalMu.Unlock(lbPoolLockKey(poolUUID.(string)))
-	}
 	return client.LoadBalancerListeners.Delete(context.Background(), id)
 }

--- a/cloudscale/resource_cloudscale_load_balancer_listener.go
+++ b/cloudscale/resource_cloudscale_load_balancer_listener.go
@@ -23,6 +23,7 @@ func loadBalancerListenerLockKey(d *schema.ResourceData) (string, bool) {
 }
 
 var (
+	resourceCloudscaleLoadBalancerListenerCreate = getCreateOperation(createLoadBalancerListener, loadBalancerListenerLockKey)
 	resourceCloudscaleLoadBalancerListenerRead   = getReadOperation(listenerHumanName, getGenericResourceIdentifierFromSchema, readLoadBalancerListener, gatherLoadBalancerListenerResourceData)
 	resourceCloudscaleLoadBalancerListenerUpdate = getUpdateOperation(listenerHumanName, getGenericResourceIdentifierFromSchema, updateLoadBalancerListener, resourceCloudscaleLoadBalancerListenerRead, gatherLoadBalancerListenerUpdateRequest, loadBalancerListenerLockKey)
 	resourceCloudscaleLoadBalancerListenerDelete = getDeleteOperation(listenerHumanName, getGenericResourceIdentifierFromSchema, deleteLoadBalancerListener, loadBalancerListenerLockKey)
@@ -30,7 +31,7 @@ var (
 
 func resourceCloudscaleLoadBalancerListener() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: withLock(loadBalancerListenerLockKey, resourceCloudscaleLoadBalancerListenerCreate),
+		CreateContext: resourceCloudscaleLoadBalancerListenerCreate,
 		ReadContext:   resourceCloudscaleLoadBalancerListenerRead,
 		UpdateContext: resourceCloudscaleLoadBalancerListenerUpdate,
 		DeleteContext: resourceCloudscaleLoadBalancerListenerDelete,
@@ -109,7 +110,7 @@ func getLoadBalancerListenerSchema(t SchemaType) map[string]*schema.Schema {
 	return m
 }
 
-func resourceCloudscaleLoadBalancerListenerCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func createLoadBalancerListener(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudscale.Client)
 
 	opts := &cloudscale.LoadBalancerListenerRequest{

--- a/cloudscale/resource_cloudscale_load_balancer_pool.go
+++ b/cloudscale/resource_cloudscale_load_balancer_pool.go
@@ -21,16 +21,16 @@ func loadBalancerPoolLockKey(d *schema.ResourceData) (string, bool) {
 
 var (
 	resourceCloudscaleLoadBalancerPoolRead   = getReadOperation(poolHumanName, getGenericResourceIdentifierFromSchema, readLoadBalancerPool, gatherLoadBalancerPoolResourceData)
-	resourceCloudscaleLoadBalancerPoolUpdate = getUpdateOperation(poolHumanName, getGenericResourceIdentifierFromSchema, updateLoadBalancerPool, resourceCloudscaleLoadBalancerPoolRead, gatherLoadBalancerPoolUpdateRequest)
-	resourceCloudscaleLoadBalancerPoolDelete = getDeleteOperation(poolHumanName, deleteLoadBalancerPool)
+	resourceCloudscaleLoadBalancerPoolUpdate = getUpdateOperation(poolHumanName, getGenericResourceIdentifierFromSchema, updateLoadBalancerPool, resourceCloudscaleLoadBalancerPoolRead, gatherLoadBalancerPoolUpdateRequest, loadBalancerPoolLockKey)
+	resourceCloudscaleLoadBalancerPoolDelete = getDeleteOperation(poolHumanName, getGenericResourceIdentifierFromSchema, deleteLoadBalancerPool, loadBalancerPoolLockKey)
 )
 
 func resourceCloudscaleLoadBalancerPool() *schema.Resource {
 	return &schema.Resource{
 		Create: withLock(loadBalancerPoolLockKey, resourceCloudscaleLoadBalancerPoolCreate),
 		Read:   resourceCloudscaleLoadBalancerPoolRead,
-		Update: withLock(loadBalancerPoolLockKey, resourceCloudscaleLoadBalancerPoolUpdate),
-		Delete: withLock(loadBalancerPoolLockKey, resourceCloudscaleLoadBalancerPoolDelete),
+		Update: resourceCloudscaleLoadBalancerPoolUpdate,
+		Delete: resourceCloudscaleLoadBalancerPoolDelete,
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -159,8 +159,7 @@ func gatherLoadBalancerPoolUpdateRequest(d *schema.ResourceData) []*cloudscale.L
 	return requests
 }
 
-func deleteLoadBalancerPool(d *schema.ResourceData, meta any) error {
+func deleteLoadBalancerPool(rId GenericResourceIdentifier, meta any) error {
 	client := meta.(*cloudscale.Client)
-	id := d.Id()
-	return client.LoadBalancerPools.Delete(context.Background(), id)
+	return client.LoadBalancerPools.Delete(context.Background(), rId.Id)
 }

--- a/cloudscale/resource_cloudscale_load_balancer_pool.go
+++ b/cloudscale/resource_cloudscale_load_balancer_pool.go
@@ -3,9 +3,11 @@ package cloudscale
 import (
 	"context"
 	"fmt"
-	"github.com/cloudscale-ch/cloudscale-go-sdk/v9"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"log"
+
+	"github.com/cloudscale-ch/cloudscale-go-sdk/v9"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 const poolHumanName = "load balancer pool"
@@ -27,10 +29,10 @@ var (
 
 func resourceCloudscaleLoadBalancerPool() *schema.Resource {
 	return &schema.Resource{
-		Create: withLock(loadBalancerPoolLockKey, resourceCloudscaleLoadBalancerPoolCreate),
-		Read:   resourceCloudscaleLoadBalancerPoolRead,
-		Update: resourceCloudscaleLoadBalancerPoolUpdate,
-		Delete: resourceCloudscaleLoadBalancerPoolDelete,
+		CreateContext: withLock(loadBalancerPoolLockKey, resourceCloudscaleLoadBalancerPoolCreate),
+		Read:          resourceCloudscaleLoadBalancerPoolRead,
+		UpdateContext: resourceCloudscaleLoadBalancerPoolUpdate,
+		DeleteContext: resourceCloudscaleLoadBalancerPoolDelete,
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -87,7 +89,7 @@ func getLoadBalancerPoolSchema(t SchemaType) map[string]*schema.Schema {
 	return m
 }
 
-func resourceCloudscaleLoadBalancerPoolCreate(d *schema.ResourceData, meta any) error {
+func resourceCloudscaleLoadBalancerPoolCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudscale.Client)
 
 	opts := &cloudscale.LoadBalancerPoolRequest{
@@ -101,19 +103,15 @@ func resourceCloudscaleLoadBalancerPoolCreate(d *schema.ResourceData, meta any) 
 
 	log.Printf("[DEBUG] LoadBalancerPool create configuration: %#v", opts)
 
-	loadBalancerPool, err := client.LoadBalancerPools.Create(context.Background(), opts)
+	loadBalancerPool, err := client.LoadBalancerPools.Create(ctx, opts)
 	if err != nil {
-		return fmt.Errorf("Error creating LoadBalancerPool: %s", err)
+		return diag.FromErr(fmt.Errorf("Error creating LoadBalancerPool: %s", err))
 	}
 
 	d.SetId(loadBalancerPool.UUID)
 
 	log.Printf("[INFO] LoadBalancerPool ID: %s", d.Id())
-	err = resourceCloudscaleLoadBalancerPoolRead(d, meta)
-	if err != nil {
-		return fmt.Errorf("Error reading the load balancer pool (%s): %s", d.Id(), err)
-	}
-	return nil
+	return diag.FromErr(resourceCloudscaleLoadBalancerPoolRead(d, meta))
 }
 
 func gatherLoadBalancerPoolResourceData(loadbalancerpool *cloudscale.LoadBalancerPool) ResourceDataRaw {
@@ -135,9 +133,9 @@ func readLoadBalancerPool(rId GenericResourceIdentifier, meta any) (*cloudscale.
 	return client.LoadBalancerPools.Get(context.Background(), rId.Id)
 }
 
-func updateLoadBalancerPool(rId GenericResourceIdentifier, meta any, updateRequest *cloudscale.LoadBalancerPoolRequest) error {
+func updateLoadBalancerPool(ctx context.Context, rId GenericResourceIdentifier, meta any, updateRequest *cloudscale.LoadBalancerPoolRequest) error {
 	client := meta.(*cloudscale.Client)
-	return client.LoadBalancerPools.Update(context.Background(), rId.Id, updateRequest)
+	return client.LoadBalancerPools.Update(ctx, rId.Id, updateRequest)
 }
 
 func gatherLoadBalancerPoolUpdateRequest(d *schema.ResourceData) []*cloudscale.LoadBalancerPoolRequest {
@@ -159,7 +157,7 @@ func gatherLoadBalancerPoolUpdateRequest(d *schema.ResourceData) []*cloudscale.L
 	return requests
 }
 
-func deleteLoadBalancerPool(rId GenericResourceIdentifier, meta any) error {
+func deleteLoadBalancerPool(ctx context.Context, rId GenericResourceIdentifier, meta any) error {
 	client := meta.(*cloudscale.Client)
-	return client.LoadBalancerPools.Delete(context.Background(), rId.Id)
+	return client.LoadBalancerPools.Delete(ctx, rId.Id)
 }

--- a/cloudscale/resource_cloudscale_load_balancer_pool.go
+++ b/cloudscale/resource_cloudscale_load_balancer_pool.go
@@ -30,7 +30,7 @@ var (
 func resourceCloudscaleLoadBalancerPool() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: withLock(loadBalancerPoolLockKey, resourceCloudscaleLoadBalancerPoolCreate),
-		Read:          resourceCloudscaleLoadBalancerPoolRead,
+		ReadContext:   resourceCloudscaleLoadBalancerPoolRead,
 		UpdateContext: resourceCloudscaleLoadBalancerPoolUpdate,
 		DeleteContext: resourceCloudscaleLoadBalancerPoolDelete,
 
@@ -111,7 +111,7 @@ func resourceCloudscaleLoadBalancerPoolCreate(ctx context.Context, d *schema.Res
 	d.SetId(loadBalancerPool.UUID)
 
 	log.Printf("[INFO] LoadBalancerPool ID: %s", d.Id())
-	return diag.FromErr(resourceCloudscaleLoadBalancerPoolRead(d, meta))
+	return resourceCloudscaleLoadBalancerPoolRead(ctx, d, meta)
 }
 
 func gatherLoadBalancerPoolResourceData(loadbalancerpool *cloudscale.LoadBalancerPool) ResourceDataRaw {
@@ -128,9 +128,9 @@ func gatherLoadBalancerPoolResourceData(loadbalancerpool *cloudscale.LoadBalance
 	return m
 }
 
-func readLoadBalancerPool(rId GenericResourceIdentifier, meta any) (*cloudscale.LoadBalancerPool, error) {
+func readLoadBalancerPool(ctx context.Context, rId GenericResourceIdentifier, meta any) (*cloudscale.LoadBalancerPool, error) {
 	client := meta.(*cloudscale.Client)
-	return client.LoadBalancerPools.Get(context.Background(), rId.Id)
+	return client.LoadBalancerPools.Get(ctx, rId.Id)
 }
 
 func updateLoadBalancerPool(ctx context.Context, rId GenericResourceIdentifier, meta any, updateRequest *cloudscale.LoadBalancerPoolRequest) error {

--- a/cloudscale/resource_cloudscale_load_balancer_pool.go
+++ b/cloudscale/resource_cloudscale_load_balancer_pool.go
@@ -10,6 +10,15 @@ import (
 
 const poolHumanName = "load balancer pool"
 
+func lbLockKey(lbUUID string) string {
+	return fmt.Sprintf("cloudscale/load-balancer/%s", lbUUID)
+}
+
+// loadBalancerPoolLockKey serializes pool operations on their parent load balancer.
+func loadBalancerPoolLockKey(d *schema.ResourceData) (string, bool) {
+	return lbLockKey(d.Get("load_balancer_uuid").(string)), true
+}
+
 var (
 	resourceCloudscaleLoadBalancerPoolRead   = getReadOperation(poolHumanName, getGenericResourceIdentifierFromSchema, readLoadBalancerPool, gatherLoadBalancerPoolResourceData)
 	resourceCloudscaleLoadBalancerPoolUpdate = getUpdateOperation(poolHumanName, getGenericResourceIdentifierFromSchema, updateLoadBalancerPool, resourceCloudscaleLoadBalancerPoolRead, gatherLoadBalancerPoolUpdateRequest)
@@ -18,10 +27,10 @@ var (
 
 func resourceCloudscaleLoadBalancerPool() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceCloudscaleLoadBalancerPoolCreate,
+		Create: withLock(loadBalancerPoolLockKey, resourceCloudscaleLoadBalancerPoolCreate),
 		Read:   resourceCloudscaleLoadBalancerPoolRead,
-		Update: resourceCloudscaleLoadBalancerPoolUpdate,
-		Delete: resourceCloudscaleLoadBalancerPoolDelete,
+		Update: withLock(loadBalancerPoolLockKey, resourceCloudscaleLoadBalancerPoolUpdate),
+		Delete: withLock(loadBalancerPoolLockKey, resourceCloudscaleLoadBalancerPoolDelete),
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -78,16 +87,8 @@ func getLoadBalancerPoolSchema(t SchemaType) map[string]*schema.Schema {
 	return m
 }
 
-func lbLockKey(lbUUID string) string {
-	return fmt.Sprintf("cloudscale/load-balancer/%s", lbUUID)
-}
-
 func resourceCloudscaleLoadBalancerPoolCreate(d *schema.ResourceData, meta any) error {
 	client := meta.(*cloudscale.Client)
-
-	lbUUID := d.Get("load_balancer_uuid").(string)
-	globalMu.Lock(lbLockKey(lbUUID))
-	defer globalMu.Unlock(lbLockKey(lbUUID))
 
 	opts := &cloudscale.LoadBalancerPoolRequest{
 		Name:         d.Get("name").(string),
@@ -161,8 +162,5 @@ func gatherLoadBalancerPoolUpdateRequest(d *schema.ResourceData) []*cloudscale.L
 func deleteLoadBalancerPool(d *schema.ResourceData, meta any) error {
 	client := meta.(*cloudscale.Client)
 	id := d.Id()
-	lbUUID := d.Get("load_balancer_uuid").(string)
-	globalMu.Lock(lbLockKey(lbUUID))
-	defer globalMu.Unlock(lbLockKey(lbUUID))
 	return client.LoadBalancerPools.Delete(context.Background(), id)
 }

--- a/cloudscale/resource_cloudscale_load_balancer_pool.go
+++ b/cloudscale/resource_cloudscale_load_balancer_pool.go
@@ -12,18 +12,13 @@ import (
 
 const poolHumanName = "load balancer pool"
 
-func lbLockKey(lbUUID string) string {
-	return fmt.Sprintf("cloudscale/load-balancer/%s", lbUUID)
-}
-
-// loadBalancerPoolLockKey serializes pool operations on their parent load balancer.
-var loadBalancerPoolLockKey = uuidLockKey("load_balancer_uuid", lbLockKey)
-
+// Pool operations serialize on the parent load balancer
+// via lockKeyFromLoadBalancerUUID.
 var (
-	resourceCloudscaleLoadBalancerPoolCreate = getCreateOperation(createLoadBalancerPool, loadBalancerPoolLockKey)
+	resourceCloudscaleLoadBalancerPoolCreate = getCreateOperation(createLoadBalancerPool, lockKeyFromLoadBalancerUUID)
 	resourceCloudscaleLoadBalancerPoolRead   = getReadOperation(poolHumanName, getGenericResourceIdentifierFromSchema, readLoadBalancerPool, gatherLoadBalancerPoolResourceData)
-	resourceCloudscaleLoadBalancerPoolUpdate = getUpdateOperation(poolHumanName, getGenericResourceIdentifierFromSchema, updateLoadBalancerPool, resourceCloudscaleLoadBalancerPoolRead, gatherLoadBalancerPoolUpdateRequest, loadBalancerPoolLockKey)
-	resourceCloudscaleLoadBalancerPoolDelete = getDeleteOperation(poolHumanName, getGenericResourceIdentifierFromSchema, deleteLoadBalancerPool, loadBalancerPoolLockKey)
+	resourceCloudscaleLoadBalancerPoolUpdate = getUpdateOperation(poolHumanName, getGenericResourceIdentifierFromSchema, updateLoadBalancerPool, resourceCloudscaleLoadBalancerPoolRead, gatherLoadBalancerPoolUpdateRequest, lockKeyFromLoadBalancerUUID)
+	resourceCloudscaleLoadBalancerPoolDelete = getDeleteOperation(poolHumanName, getGenericResourceIdentifierFromSchema, deleteLoadBalancerPool, lockKeyFromLoadBalancerUUID)
 )
 
 func resourceCloudscaleLoadBalancerPool() *schema.Resource {

--- a/cloudscale/resource_cloudscale_load_balancer_pool.go
+++ b/cloudscale/resource_cloudscale_load_balancer_pool.go
@@ -17,9 +17,7 @@ func lbLockKey(lbUUID string) string {
 }
 
 // loadBalancerPoolLockKey serializes pool operations on their parent load balancer.
-func loadBalancerPoolLockKey(d *schema.ResourceData) (string, bool) {
-	return lbLockKey(d.Get("load_balancer_uuid").(string)), true
-}
+var loadBalancerPoolLockKey = uuidLockKey("load_balancer_uuid", lbLockKey)
 
 var (
 	resourceCloudscaleLoadBalancerPoolRead   = getReadOperation(poolHumanName, getGenericResourceIdentifierFromSchema, readLoadBalancerPool, gatherLoadBalancerPoolResourceData)

--- a/cloudscale/resource_cloudscale_load_balancer_pool.go
+++ b/cloudscale/resource_cloudscale_load_balancer_pool.go
@@ -78,8 +78,16 @@ func getLoadBalancerPoolSchema(t SchemaType) map[string]*schema.Schema {
 	return m
 }
 
+func lbLockKey(lbUUID string) string {
+	return fmt.Sprintf("cloudscale/load-balancer/%s", lbUUID)
+}
+
 func resourceCloudscaleLoadBalancerPoolCreate(d *schema.ResourceData, meta any) error {
 	client := meta.(*cloudscale.Client)
+
+	lbUUID := d.Get("load_balancer_uuid").(string)
+	globalMu.Lock(lbLockKey(lbUUID))
+	defer globalMu.Unlock(lbLockKey(lbUUID))
 
 	opts := &cloudscale.LoadBalancerPoolRequest{
 		Name:         d.Get("name").(string),
@@ -153,5 +161,8 @@ func gatherLoadBalancerPoolUpdateRequest(d *schema.ResourceData) []*cloudscale.L
 func deleteLoadBalancerPool(d *schema.ResourceData, meta any) error {
 	client := meta.(*cloudscale.Client)
 	id := d.Id()
+	lbUUID := d.Get("load_balancer_uuid").(string)
+	globalMu.Lock(lbLockKey(lbUUID))
+	defer globalMu.Unlock(lbLockKey(lbUUID))
 	return client.LoadBalancerPools.Delete(context.Background(), id)
 }

--- a/cloudscale/resource_cloudscale_load_balancer_pool.go
+++ b/cloudscale/resource_cloudscale_load_balancer_pool.go
@@ -20,6 +20,7 @@ func lbLockKey(lbUUID string) string {
 var loadBalancerPoolLockKey = uuidLockKey("load_balancer_uuid", lbLockKey)
 
 var (
+	resourceCloudscaleLoadBalancerPoolCreate = getCreateOperation(createLoadBalancerPool, loadBalancerPoolLockKey)
 	resourceCloudscaleLoadBalancerPoolRead   = getReadOperation(poolHumanName, getGenericResourceIdentifierFromSchema, readLoadBalancerPool, gatherLoadBalancerPoolResourceData)
 	resourceCloudscaleLoadBalancerPoolUpdate = getUpdateOperation(poolHumanName, getGenericResourceIdentifierFromSchema, updateLoadBalancerPool, resourceCloudscaleLoadBalancerPoolRead, gatherLoadBalancerPoolUpdateRequest, loadBalancerPoolLockKey)
 	resourceCloudscaleLoadBalancerPoolDelete = getDeleteOperation(poolHumanName, getGenericResourceIdentifierFromSchema, deleteLoadBalancerPool, loadBalancerPoolLockKey)
@@ -27,7 +28,7 @@ var (
 
 func resourceCloudscaleLoadBalancerPool() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: withLock(loadBalancerPoolLockKey, resourceCloudscaleLoadBalancerPoolCreate),
+		CreateContext: resourceCloudscaleLoadBalancerPoolCreate,
 		ReadContext:   resourceCloudscaleLoadBalancerPoolRead,
 		UpdateContext: resourceCloudscaleLoadBalancerPoolUpdate,
 		DeleteContext: resourceCloudscaleLoadBalancerPoolDelete,
@@ -87,7 +88,7 @@ func getLoadBalancerPoolSchema(t SchemaType) map[string]*schema.Schema {
 	return m
 }
 
-func resourceCloudscaleLoadBalancerPoolCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func createLoadBalancerPool(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudscale.Client)
 
 	opts := &cloudscale.LoadBalancerPoolRequest{

--- a/cloudscale/resource_cloudscale_load_balancer_pool_member.go
+++ b/cloudscale/resource_cloudscale_load_balancer_pool_member.go
@@ -22,16 +22,16 @@ func loadBalancerPoolMemberLockKey(d *schema.ResourceData) (string, bool) {
 
 var (
 	resourceCloudscaleLoadBalancerPoolMemberRead   = getReadOperation(poolMemberHumanName, getLoadBalancerResourceIdentifierFromSchema, readLoadBalancerPoolMember, gatherLoadBalancerPoolMemberResourceData)
-	resourceCloudscaleLoadBalancerPoolMemberUpdate = getUpdateOperation(poolMemberHumanName, getLoadBalancerResourceIdentifierFromSchema, updateLoadBalancerPoolMember, resourceCloudscaleLoadBalancerPoolMemberRead, gatherLoadBalancerPoolMemberUpdateRequest)
-	resourceCloudscaleLoadBalancerPoolMemberDelete = getDeleteOperation(poolMemberHumanName, deleteLoadBalancerPoolMember)
+	resourceCloudscaleLoadBalancerPoolMemberUpdate = getUpdateOperation(poolMemberHumanName, getLoadBalancerResourceIdentifierFromSchema, updateLoadBalancerPoolMember, resourceCloudscaleLoadBalancerPoolMemberRead, gatherLoadBalancerPoolMemberUpdateRequest, loadBalancerPoolMemberLockKey)
+	resourceCloudscaleLoadBalancerPoolMemberDelete = getDeleteOperation(poolMemberHumanName, getLoadBalancerResourceIdentifierFromSchema, deleteLoadBalancerPoolMember, loadBalancerPoolMemberLockKey)
 )
 
 func resourceCloudscaleLoadBalancerPoolMembers() *schema.Resource {
 	return &schema.Resource{
 		Create: withLock(loadBalancerPoolMemberLockKey, resourceCloudscaleLoadBalancerPoolMemberCreate),
 		Read:   resourceCloudscaleLoadBalancerPoolMemberRead,
-		Update: withLock(loadBalancerPoolMemberLockKey, resourceCloudscaleLoadBalancerPoolMemberUpdate),
-		Delete: withLock(loadBalancerPoolMemberLockKey, resourceCloudscaleLoadBalancerPoolMemberDelete),
+		Update: resourceCloudscaleLoadBalancerPoolMemberUpdate,
+		Delete: resourceCloudscaleLoadBalancerPoolMemberDelete,
 
 		Importer: &schema.ResourceImporter{
 			StateContext: func(
@@ -240,9 +240,7 @@ func gatherLoadBalancerPoolMemberUpdateRequest(d *schema.ResourceData) []*clouds
 	return requests
 }
 
-func deleteLoadBalancerPoolMember(d *schema.ResourceData, meta any) error {
+func deleteLoadBalancerPoolMember(rId LoadBalancerPoolMemberResourceIdentifier, meta any) error {
 	client := meta.(*cloudscale.Client)
-	id := d.Id()
-	poolID := d.Get("pool_uuid").(string)
-	return client.LoadBalancerPoolMembers.Delete(context.Background(), poolID, id)
+	return client.LoadBalancerPoolMembers.Delete(context.Background(), rId.PoolID, rId.Id)
 }

--- a/cloudscale/resource_cloudscale_load_balancer_pool_member.go
+++ b/cloudscale/resource_cloudscale_load_balancer_pool_member.go
@@ -11,6 +11,15 @@ import (
 
 const poolMemberHumanName = "load balancer pool member"
 
+func lbPoolLockKey(poolUUID string) string {
+	return fmt.Sprintf("cloudscale/load-balancer-pool/%s", poolUUID)
+}
+
+// loadBalancerPoolMemberLockKey serializes pool member operations on their parent pool.
+func loadBalancerPoolMemberLockKey(d *schema.ResourceData) (string, bool) {
+	return lbPoolLockKey(d.Get("pool_uuid").(string)), true
+}
+
 var (
 	resourceCloudscaleLoadBalancerPoolMemberRead   = getReadOperation(poolMemberHumanName, getLoadBalancerResourceIdentifierFromSchema, readLoadBalancerPoolMember, gatherLoadBalancerPoolMemberResourceData)
 	resourceCloudscaleLoadBalancerPoolMemberUpdate = getUpdateOperation(poolMemberHumanName, getLoadBalancerResourceIdentifierFromSchema, updateLoadBalancerPoolMember, resourceCloudscaleLoadBalancerPoolMemberRead, gatherLoadBalancerPoolMemberUpdateRequest)
@@ -19,10 +28,10 @@ var (
 
 func resourceCloudscaleLoadBalancerPoolMembers() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceCloudscaleLoadBalancerPoolMemberCreate,
+		Create: withLock(loadBalancerPoolMemberLockKey, resourceCloudscaleLoadBalancerPoolMemberCreate),
 		Read:   resourceCloudscaleLoadBalancerPoolMemberRead,
-		Update: resourceCloudscaleLoadBalancerPoolMemberUpdate,
-		Delete: resourceCloudscaleLoadBalancerPoolMemberDelete,
+		Update: withLock(loadBalancerPoolMemberLockKey, resourceCloudscaleLoadBalancerPoolMemberUpdate),
+		Delete: withLock(loadBalancerPoolMemberLockKey, resourceCloudscaleLoadBalancerPoolMemberDelete),
 
 		Importer: &schema.ResourceImporter{
 			StateContext: func(
@@ -145,10 +154,6 @@ func getLoadBalancerPoolMemberSchema(t SchemaType) map[string]*schema.Schema {
 	return m
 }
 
-func lbPoolLockKey(poolUUID string) string {
-	return fmt.Sprintf("cloudscale/load-balancer-pool/%s", poolUUID)
-}
-
 func resourceCloudscaleLoadBalancerPoolMemberCreate(d *schema.ResourceData, meta any) error {
 	client := meta.(*cloudscale.Client)
 
@@ -168,8 +173,6 @@ func resourceCloudscaleLoadBalancerPoolMemberCreate(d *schema.ResourceData, meta
 	log.Printf("[DEBUG] LoadBalancerPoolMember create configuration: %#v", opts)
 
 	poolID := d.Get("pool_uuid").(string)
-	globalMu.Lock(lbPoolLockKey(poolID))
-	defer globalMu.Unlock(lbPoolLockKey(poolID))
 	poolMember, err := client.LoadBalancerPoolMembers.Create(context.Background(), poolID, opts)
 	if err != nil {
 		return fmt.Errorf("Error creating LoadBalancerPoolMember: %s", err)
@@ -241,7 +244,5 @@ func deleteLoadBalancerPoolMember(d *schema.ResourceData, meta any) error {
 	client := meta.(*cloudscale.Client)
 	id := d.Id()
 	poolID := d.Get("pool_uuid").(string)
-	globalMu.Lock(lbPoolLockKey(poolID))
-	defer globalMu.Unlock(lbPoolLockKey(poolID))
 	return client.LoadBalancerPoolMembers.Delete(context.Background(), poolID, id)
 }

--- a/cloudscale/resource_cloudscale_load_balancer_pool_member.go
+++ b/cloudscale/resource_cloudscale_load_balancer_pool_member.go
@@ -21,6 +21,7 @@ func lbPoolLockKey(poolUUID string) string {
 var loadBalancerPoolMemberLockKey = uuidLockKey("pool_uuid", lbPoolLockKey)
 
 var (
+	resourceCloudscaleLoadBalancerPoolMemberCreate = getCreateOperation(createLoadBalancerPoolMember, loadBalancerPoolMemberLockKey)
 	resourceCloudscaleLoadBalancerPoolMemberRead   = getReadOperation(poolMemberHumanName, getLoadBalancerResourceIdentifierFromSchema, readLoadBalancerPoolMember, gatherLoadBalancerPoolMemberResourceData)
 	resourceCloudscaleLoadBalancerPoolMemberUpdate = getUpdateOperation(poolMemberHumanName, getLoadBalancerResourceIdentifierFromSchema, updateLoadBalancerPoolMember, resourceCloudscaleLoadBalancerPoolMemberRead, gatherLoadBalancerPoolMemberUpdateRequest, loadBalancerPoolMemberLockKey)
 	resourceCloudscaleLoadBalancerPoolMemberDelete = getDeleteOperation(poolMemberHumanName, getLoadBalancerResourceIdentifierFromSchema, deleteLoadBalancerPoolMember, loadBalancerPoolMemberLockKey)
@@ -28,7 +29,7 @@ var (
 
 func resourceCloudscaleLoadBalancerPoolMembers() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: withLock(loadBalancerPoolMemberLockKey, resourceCloudscaleLoadBalancerPoolMemberCreate),
+		CreateContext: resourceCloudscaleLoadBalancerPoolMemberCreate,
 		ReadContext:   resourceCloudscaleLoadBalancerPoolMemberRead,
 		UpdateContext: resourceCloudscaleLoadBalancerPoolMemberUpdate,
 		DeleteContext: resourceCloudscaleLoadBalancerPoolMemberDelete,
@@ -154,7 +155,7 @@ func getLoadBalancerPoolMemberSchema(t SchemaType) map[string]*schema.Schema {
 	return m
 }
 
-func resourceCloudscaleLoadBalancerPoolMemberCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func createLoadBalancerPoolMember(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudscale.Client)
 
 	opts := &cloudscale.LoadBalancerPoolMemberRequest{

--- a/cloudscale/resource_cloudscale_load_balancer_pool_member.go
+++ b/cloudscale/resource_cloudscale_load_balancer_pool_member.go
@@ -145,6 +145,10 @@ func getLoadBalancerPoolMemberSchema(t SchemaType) map[string]*schema.Schema {
 	return m
 }
 
+func lbPoolLockKey(poolUUID string) string {
+	return fmt.Sprintf("cloudscale/load-balancer-pool/%s", poolUUID)
+}
+
 func resourceCloudscaleLoadBalancerPoolMemberCreate(d *schema.ResourceData, meta any) error {
 	client := meta.(*cloudscale.Client)
 
@@ -164,6 +168,8 @@ func resourceCloudscaleLoadBalancerPoolMemberCreate(d *schema.ResourceData, meta
 	log.Printf("[DEBUG] LoadBalancerPoolMember create configuration: %#v", opts)
 
 	poolID := d.Get("pool_uuid").(string)
+	globalMu.Lock(lbPoolLockKey(poolID))
+	defer globalMu.Unlock(lbPoolLockKey(poolID))
 	poolMember, err := client.LoadBalancerPoolMembers.Create(context.Background(), poolID, opts)
 	if err != nil {
 		return fmt.Errorf("Error creating LoadBalancerPoolMember: %s", err)
@@ -235,5 +241,7 @@ func deleteLoadBalancerPoolMember(d *schema.ResourceData, meta any) error {
 	client := meta.(*cloudscale.Client)
 	id := d.Id()
 	poolID := d.Get("pool_uuid").(string)
+	globalMu.Lock(lbPoolLockKey(poolID))
+	defer globalMu.Unlock(lbPoolLockKey(poolID))
 	return client.LoadBalancerPoolMembers.Delete(context.Background(), poolID, id)
 }

--- a/cloudscale/resource_cloudscale_load_balancer_pool_member.go
+++ b/cloudscale/resource_cloudscale_load_balancer_pool_member.go
@@ -31,7 +31,7 @@ var (
 func resourceCloudscaleLoadBalancerPoolMembers() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: withLock(loadBalancerPoolMemberLockKey, resourceCloudscaleLoadBalancerPoolMemberCreate),
-		Read:          resourceCloudscaleLoadBalancerPoolMemberRead,
+		ReadContext:   resourceCloudscaleLoadBalancerPoolMemberRead,
 		UpdateContext: resourceCloudscaleLoadBalancerPoolMemberUpdate,
 		DeleteContext: resourceCloudscaleLoadBalancerPoolMemberDelete,
 
@@ -183,7 +183,7 @@ func resourceCloudscaleLoadBalancerPoolMemberCreate(ctx context.Context, d *sche
 	d.SetId(poolMember.UUID)
 
 	log.Printf("[INFO] LoadBalancerPoolMember ID: %s", d.Id())
-	return diag.FromErr(resourceCloudscaleLoadBalancerPoolMemberRead(d, meta))
+	return resourceCloudscaleLoadBalancerPoolMemberRead(ctx, d, meta)
 }
 
 func gatherLoadBalancerPoolMemberResourceData(loadbalancerPoolMember *cloudscale.LoadBalancerPoolMember) ResourceDataRaw {
@@ -206,9 +206,9 @@ func gatherLoadBalancerPoolMemberResourceData(loadbalancerPoolMember *cloudscale
 	return m
 }
 
-func readLoadBalancerPoolMember(rId LoadBalancerPoolMemberResourceIdentifier, meta any) (*cloudscale.LoadBalancerPoolMember, error) {
+func readLoadBalancerPoolMember(ctx context.Context, rId LoadBalancerPoolMemberResourceIdentifier, meta any) (*cloudscale.LoadBalancerPoolMember, error) {
 	client := meta.(*cloudscale.Client)
-	return client.LoadBalancerPoolMembers.Get(context.Background(), rId.PoolID, rId.Id)
+	return client.LoadBalancerPoolMembers.Get(ctx, rId.PoolID, rId.Id)
 }
 
 func updateLoadBalancerPoolMember(ctx context.Context, rId LoadBalancerPoolMemberResourceIdentifier, meta any, updateRequest *cloudscale.LoadBalancerPoolMemberRequest) error {

--- a/cloudscale/resource_cloudscale_load_balancer_pool_member.go
+++ b/cloudscale/resource_cloudscale_load_balancer_pool_member.go
@@ -3,10 +3,12 @@ package cloudscale
 import (
 	"context"
 	"fmt"
-	"github.com/cloudscale-ch/cloudscale-go-sdk/v9"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"log"
 	"strings"
+
+	"github.com/cloudscale-ch/cloudscale-go-sdk/v9"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 const poolMemberHumanName = "load balancer pool member"
@@ -28,10 +30,10 @@ var (
 
 func resourceCloudscaleLoadBalancerPoolMembers() *schema.Resource {
 	return &schema.Resource{
-		Create: withLock(loadBalancerPoolMemberLockKey, resourceCloudscaleLoadBalancerPoolMemberCreate),
-		Read:   resourceCloudscaleLoadBalancerPoolMemberRead,
-		Update: resourceCloudscaleLoadBalancerPoolMemberUpdate,
-		Delete: resourceCloudscaleLoadBalancerPoolMemberDelete,
+		CreateContext: withLock(loadBalancerPoolMemberLockKey, resourceCloudscaleLoadBalancerPoolMemberCreate),
+		Read:          resourceCloudscaleLoadBalancerPoolMemberRead,
+		UpdateContext: resourceCloudscaleLoadBalancerPoolMemberUpdate,
+		DeleteContext: resourceCloudscaleLoadBalancerPoolMemberDelete,
 
 		Importer: &schema.ResourceImporter{
 			StateContext: func(
@@ -154,7 +156,7 @@ func getLoadBalancerPoolMemberSchema(t SchemaType) map[string]*schema.Schema {
 	return m
 }
 
-func resourceCloudscaleLoadBalancerPoolMemberCreate(d *schema.ResourceData, meta any) error {
+func resourceCloudscaleLoadBalancerPoolMemberCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*cloudscale.Client)
 
 	opts := &cloudscale.LoadBalancerPoolMemberRequest{
@@ -173,19 +175,15 @@ func resourceCloudscaleLoadBalancerPoolMemberCreate(d *schema.ResourceData, meta
 	log.Printf("[DEBUG] LoadBalancerPoolMember create configuration: %#v", opts)
 
 	poolID := d.Get("pool_uuid").(string)
-	poolMember, err := client.LoadBalancerPoolMembers.Create(context.Background(), poolID, opts)
+	poolMember, err := client.LoadBalancerPoolMembers.Create(ctx, poolID, opts)
 	if err != nil {
-		return fmt.Errorf("Error creating LoadBalancerPoolMember: %s", err)
+		return diag.FromErr(fmt.Errorf("Error creating LoadBalancerPoolMember: %s", err))
 	}
 
 	d.SetId(poolMember.UUID)
 
 	log.Printf("[INFO] LoadBalancerPoolMember ID: %s", d.Id())
-	err = resourceCloudscaleLoadBalancerPoolMemberRead(d, meta)
-	if err != nil {
-		return fmt.Errorf("Error reading the load balancer pool member (%s): %s", d.Id(), err)
-	}
-	return nil
+	return diag.FromErr(resourceCloudscaleLoadBalancerPoolMemberRead(d, meta))
 }
 
 func gatherLoadBalancerPoolMemberResourceData(loadbalancerPoolMember *cloudscale.LoadBalancerPoolMember) ResourceDataRaw {
@@ -213,9 +211,9 @@ func readLoadBalancerPoolMember(rId LoadBalancerPoolMemberResourceIdentifier, me
 	return client.LoadBalancerPoolMembers.Get(context.Background(), rId.PoolID, rId.Id)
 }
 
-func updateLoadBalancerPoolMember(rId LoadBalancerPoolMemberResourceIdentifier, meta any, updateRequest *cloudscale.LoadBalancerPoolMemberRequest) error {
+func updateLoadBalancerPoolMember(ctx context.Context, rId LoadBalancerPoolMemberResourceIdentifier, meta any, updateRequest *cloudscale.LoadBalancerPoolMemberRequest) error {
 	client := meta.(*cloudscale.Client)
-	return client.LoadBalancerPoolMembers.Update(context.Background(), rId.PoolID, rId.Id, updateRequest)
+	return client.LoadBalancerPoolMembers.Update(ctx, rId.PoolID, rId.Id, updateRequest)
 }
 
 func gatherLoadBalancerPoolMemberUpdateRequest(d *schema.ResourceData) []*cloudscale.LoadBalancerPoolMemberRequest {
@@ -240,7 +238,7 @@ func gatherLoadBalancerPoolMemberUpdateRequest(d *schema.ResourceData) []*clouds
 	return requests
 }
 
-func deleteLoadBalancerPoolMember(rId LoadBalancerPoolMemberResourceIdentifier, meta any) error {
+func deleteLoadBalancerPoolMember(ctx context.Context, rId LoadBalancerPoolMemberResourceIdentifier, meta any) error {
 	client := meta.(*cloudscale.Client)
-	return client.LoadBalancerPoolMembers.Delete(context.Background(), rId.PoolID, rId.Id)
+	return client.LoadBalancerPoolMembers.Delete(ctx, rId.PoolID, rId.Id)
 }

--- a/cloudscale/resource_cloudscale_load_balancer_pool_member.go
+++ b/cloudscale/resource_cloudscale_load_balancer_pool_member.go
@@ -18,9 +18,7 @@ func lbPoolLockKey(poolUUID string) string {
 }
 
 // loadBalancerPoolMemberLockKey serializes pool member operations on their parent pool.
-func loadBalancerPoolMemberLockKey(d *schema.ResourceData) (string, bool) {
-	return lbPoolLockKey(d.Get("pool_uuid").(string)), true
-}
+var loadBalancerPoolMemberLockKey = uuidLockKey("pool_uuid", lbPoolLockKey)
 
 var (
 	resourceCloudscaleLoadBalancerPoolMemberRead   = getReadOperation(poolMemberHumanName, getLoadBalancerResourceIdentifierFromSchema, readLoadBalancerPoolMember, gatherLoadBalancerPoolMemberResourceData)

--- a/cloudscale/resource_cloudscale_load_balancer_pool_member.go
+++ b/cloudscale/resource_cloudscale_load_balancer_pool_member.go
@@ -13,18 +13,13 @@ import (
 
 const poolMemberHumanName = "load balancer pool member"
 
-func lbPoolLockKey(poolUUID string) string {
-	return fmt.Sprintf("cloudscale/load-balancer-pool/%s", poolUUID)
-}
-
-// loadBalancerPoolMemberLockKey serializes pool member operations on their parent pool.
-var loadBalancerPoolMemberLockKey = uuidLockKey("pool_uuid", lbPoolLockKey)
-
+// Pool member operations serialize on the load balancer that owns the parent pool
+// via lockKeyFromPoolUUID.
 var (
-	resourceCloudscaleLoadBalancerPoolMemberCreate = getCreateOperation(createLoadBalancerPoolMember, loadBalancerPoolMemberLockKey)
+	resourceCloudscaleLoadBalancerPoolMemberCreate = getCreateOperation(createLoadBalancerPoolMember, lockKeyFromPoolUUID)
 	resourceCloudscaleLoadBalancerPoolMemberRead   = getReadOperation(poolMemberHumanName, getLoadBalancerResourceIdentifierFromSchema, readLoadBalancerPoolMember, gatherLoadBalancerPoolMemberResourceData)
-	resourceCloudscaleLoadBalancerPoolMemberUpdate = getUpdateOperation(poolMemberHumanName, getLoadBalancerResourceIdentifierFromSchema, updateLoadBalancerPoolMember, resourceCloudscaleLoadBalancerPoolMemberRead, gatherLoadBalancerPoolMemberUpdateRequest, loadBalancerPoolMemberLockKey)
-	resourceCloudscaleLoadBalancerPoolMemberDelete = getDeleteOperation(poolMemberHumanName, getLoadBalancerResourceIdentifierFromSchema, deleteLoadBalancerPoolMember, loadBalancerPoolMemberLockKey)
+	resourceCloudscaleLoadBalancerPoolMemberUpdate = getUpdateOperation(poolMemberHumanName, getLoadBalancerResourceIdentifierFromSchema, updateLoadBalancerPoolMember, resourceCloudscaleLoadBalancerPoolMemberRead, gatherLoadBalancerPoolMemberUpdateRequest, lockKeyFromPoolUUID)
+	resourceCloudscaleLoadBalancerPoolMemberDelete = getDeleteOperation(poolMemberHumanName, getLoadBalancerResourceIdentifierFromSchema, deleteLoadBalancerPoolMember, lockKeyFromPoolUUID)
 )
 
 func resourceCloudscaleLoadBalancerPoolMembers() *schema.Resource {

--- a/cloudscale/resource_cloudscale_network.go
+++ b/cloudscale/resource_cloudscale_network.go
@@ -13,8 +13,8 @@ const networkHumanName = "network"
 
 var (
 	resourceCloudscaleNetworkRead   = getReadOperation(networkHumanName, getGenericResourceIdentifierFromSchema, readNetwork, gatherNetworkResourceData)
-	resourceCloudscaleNetworkUpdate = getUpdateOperation(networkHumanName, getGenericResourceIdentifierFromSchema, updateNetwork, resourceCloudscaleNetworkRead, gatherNetworkUpdateRequest)
-	resourceCloudscaleNetworkDelete = getDeleteOperation(networkHumanName, deleteNetwork)
+	resourceCloudscaleNetworkUpdate = getUpdateOperation(networkHumanName, getGenericResourceIdentifierFromSchema, updateNetwork, resourceCloudscaleNetworkRead, gatherNetworkUpdateRequest, nil)
+	resourceCloudscaleNetworkDelete = getDeleteOperation(networkHumanName, getGenericResourceIdentifierFromSchema, deleteNetwork, nil)
 )
 
 func resourceCloudscaleNetwork() *schema.Resource {
@@ -179,8 +179,7 @@ func gatherNetworkUpdateRequest(d *schema.ResourceData) []*cloudscale.NetworkUpd
 	return requests
 }
 
-func deleteNetwork(d *schema.ResourceData, meta any) error {
+func deleteNetwork(rId GenericResourceIdentifier, meta any) error {
 	client := meta.(*cloudscale.Client)
-	id := d.Id()
-	return client.Networks.Delete(context.Background(), id)
+	return client.Networks.Delete(context.Background(), rId.Id)
 }

--- a/cloudscale/resource_cloudscale_network.go
+++ b/cloudscale/resource_cloudscale_network.go
@@ -6,6 +6,7 @@ import (
 	"log"
 
 	"github.com/cloudscale-ch/cloudscale-go-sdk/v9"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -19,8 +20,8 @@ var (
 
 func resourceCloudscaleNetwork() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceCloudscaleNetworkCreate,
-		Read:   resourceCloudscaleNetworkRead,
+		CreateContext: resourceCloudscaleNetworkCreate,
+		ReadContext:   resourceCloudscaleNetworkRead,
 		UpdateContext: resourceCloudscaleNetworkUpdate,
 		DeleteContext: resourceCloudscaleNetworkDelete,
 
@@ -91,7 +92,7 @@ func getNetworkSchema(t SchemaType) map[string]*schema.Schema {
 	return m
 }
 
-func resourceCloudscaleNetworkCreate(d *schema.ResourceData, meta any) error {
+func resourceCloudscaleNetworkCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*cloudscale.Client)
 
 	opts := &cloudscale.NetworkCreateRequest{
@@ -112,19 +113,15 @@ func resourceCloudscaleNetworkCreate(d *schema.ResourceData, meta any) error {
 
 	log.Printf("[DEBUG] Network create configuration: %#v", opts)
 
-	network, err := client.Networks.Create(context.Background(), opts)
+	network, err := client.Networks.Create(ctx, opts)
 	if err != nil {
-		return fmt.Errorf("Error creating network: %s", err)
+		return diag.FromErr(fmt.Errorf("Error creating network: %s", err))
 	}
 
 	d.SetId(network.UUID)
 
 	log.Printf("[INFO] Network ID %s", d.Id())
-	err = resourceCloudscaleNetworkRead(d, meta)
-	if err != nil {
-		return fmt.Errorf("Error reading the network (%s): %s", d.Id(), err)
-	}
-	return nil
+	return resourceCloudscaleNetworkRead(ctx, d, meta)
 }
 
 func gatherNetworkResourceData(network *cloudscale.Network) ResourceDataRaw {
@@ -148,9 +145,9 @@ func gatherNetworkResourceData(network *cloudscale.Network) ResourceDataRaw {
 	return m
 }
 
-func readNetwork(rId GenericResourceIdentifier, meta any) (*cloudscale.Network, error) {
+func readNetwork(ctx context.Context, rId GenericResourceIdentifier, meta any) (*cloudscale.Network, error) {
 	client := meta.(*cloudscale.Client)
-	return client.Networks.Get(context.Background(), rId.Id)
+	return client.Networks.Get(ctx, rId.Id)
 }
 
 func updateNetwork(ctx context.Context, rId GenericResourceIdentifier, meta any, updateRequest *cloudscale.NetworkUpdateRequest) error {

--- a/cloudscale/resource_cloudscale_network.go
+++ b/cloudscale/resource_cloudscale_network.go
@@ -13,6 +13,7 @@ import (
 const networkHumanName = "network"
 
 var (
+	resourceCloudscaleNetworkCreate = getCreateOperation(createNetwork, nil)
 	resourceCloudscaleNetworkRead   = getReadOperation(networkHumanName, getGenericResourceIdentifierFromSchema, readNetwork, gatherNetworkResourceData)
 	resourceCloudscaleNetworkUpdate = getUpdateOperation(networkHumanName, getGenericResourceIdentifierFromSchema, updateNetwork, resourceCloudscaleNetworkRead, gatherNetworkUpdateRequest, nil)
 	resourceCloudscaleNetworkDelete = getDeleteOperation(networkHumanName, getGenericResourceIdentifierFromSchema, deleteNetwork, nil)
@@ -92,7 +93,7 @@ func getNetworkSchema(t SchemaType) map[string]*schema.Schema {
 	return m
 }
 
-func resourceCloudscaleNetworkCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func createNetwork(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*cloudscale.Client)
 
 	opts := &cloudscale.NetworkCreateRequest{

--- a/cloudscale/resource_cloudscale_network.go
+++ b/cloudscale/resource_cloudscale_network.go
@@ -21,8 +21,8 @@ func resourceCloudscaleNetwork() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceCloudscaleNetworkCreate,
 		Read:   resourceCloudscaleNetworkRead,
-		Update: resourceCloudscaleNetworkUpdate,
-		Delete: resourceCloudscaleNetworkDelete,
+		UpdateContext: resourceCloudscaleNetworkUpdate,
+		DeleteContext: resourceCloudscaleNetworkDelete,
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -153,9 +153,9 @@ func readNetwork(rId GenericResourceIdentifier, meta any) (*cloudscale.Network, 
 	return client.Networks.Get(context.Background(), rId.Id)
 }
 
-func updateNetwork(rId GenericResourceIdentifier, meta any, updateRequest *cloudscale.NetworkUpdateRequest) error {
+func updateNetwork(ctx context.Context, rId GenericResourceIdentifier, meta any, updateRequest *cloudscale.NetworkUpdateRequest) error {
 	client := meta.(*cloudscale.Client)
-	return client.Networks.Update(context.Background(), rId.Id, updateRequest)
+	return client.Networks.Update(ctx, rId.Id, updateRequest)
 }
 
 func gatherNetworkUpdateRequest(d *schema.ResourceData) []*cloudscale.NetworkUpdateRequest {
@@ -179,7 +179,7 @@ func gatherNetworkUpdateRequest(d *schema.ResourceData) []*cloudscale.NetworkUpd
 	return requests
 }
 
-func deleteNetwork(rId GenericResourceIdentifier, meta any) error {
+func deleteNetwork(ctx context.Context, rId GenericResourceIdentifier, meta any) error {
 	client := meta.(*cloudscale.Client)
-	return client.Networks.Delete(context.Background(), rId.Id)
+	return client.Networks.Delete(ctx, rId.Id)
 }

--- a/cloudscale/resource_cloudscale_objects_user.go
+++ b/cloudscale/resource_cloudscale_objects_user.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/cloudscale-ch/cloudscale-go-sdk/v9"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"log"
 )
@@ -18,8 +19,8 @@ var (
 
 func resourceCloudscaleObjectsUser() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceCloudscaleObjectsUserCreate,
-		Read:   resourceCloudscaleObjectsUserRead,
+		CreateContext: resourceCloudscaleObjectsUserCreate,
+		ReadContext:   resourceCloudscaleObjectsUserRead,
 		UpdateContext: resourceCloudscaleObjectsUserUpdate,
 		DeleteContext: resourceCloudscaleObjectsUserDelete,
 
@@ -74,7 +75,7 @@ func getObjectsUserSchema(t SchemaType) map[string]*schema.Schema {
 	return m
 }
 
-func resourceCloudscaleObjectsUserCreate(d *schema.ResourceData, meta any) error {
+func resourceCloudscaleObjectsUserCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*cloudscale.Client)
 
 	opts := &cloudscale.ObjectsUserRequest{
@@ -82,20 +83,16 @@ func resourceCloudscaleObjectsUserCreate(d *schema.ResourceData, meta any) error
 	}
 	opts.Tags = CopyTags(d)
 
-	objectsUser, err := client.ObjectsUsers.Create(context.Background(), opts)
+	objectsUser, err := client.ObjectsUsers.Create(ctx, opts)
 	if err != nil {
-		return fmt.Errorf("Error creating objects user: %s", err)
+		return diag.FromErr(fmt.Errorf("Error creating objects user: %s", err))
 	}
 
 	d.SetId(objectsUser.ID)
 
 	log.Printf("[INFO] Objects user ID %s", d.Id())
 
-	err = resourceCloudscaleObjectsUserRead(d, meta)
-	if err != nil {
-		return fmt.Errorf("Error reading the objects user (%s): %s", d.Id(), err)
-	}
-	return nil
+	return resourceCloudscaleObjectsUserRead(ctx, d, meta)
 }
 
 func gatherObjectsUserResourceData(objectsUser *cloudscale.ObjectsUser) ResourceDataRaw {
@@ -118,9 +115,9 @@ func gatherObjectsUserResourceData(objectsUser *cloudscale.ObjectsUser) Resource
 	return m
 }
 
-func readObjectsUser(rId GenericResourceIdentifier, meta any) (*cloudscale.ObjectsUser, error) {
+func readObjectsUser(ctx context.Context, rId GenericResourceIdentifier, meta any) (*cloudscale.ObjectsUser, error) {
 	client := meta.(*cloudscale.Client)
-	return client.ObjectsUsers.Get(context.Background(), rId.Id)
+	return client.ObjectsUsers.Get(ctx, rId.Id)
 }
 
 func updateObjectsUser(ctx context.Context, rId GenericResourceIdentifier, meta any, updateRequest *cloudscale.ObjectsUserRequest) error {

--- a/cloudscale/resource_cloudscale_objects_user.go
+++ b/cloudscale/resource_cloudscale_objects_user.go
@@ -12,6 +12,7 @@ import (
 const objectsUserHumanName = "Objects User"
 
 var (
+	resourceCloudscaleObjectsUserCreate = getCreateOperation(createObjectsUser, nil)
 	resourceCloudscaleObjectsUserRead   = getReadOperation(objectsUserHumanName, getGenericResourceIdentifierFromSchema, readObjectsUser, gatherObjectsUserResourceData)
 	resourceCloudscaleObjectsUserUpdate = getUpdateOperation(objectsUserHumanName, getGenericResourceIdentifierFromSchema, updateObjectsUser, resourceCloudscaleObjectsUserRead, gatherObjectsUserUpdateRequest, nil)
 	resourceCloudscaleObjectsUserDelete = getDeleteOperation(objectsUserHumanName, getGenericResourceIdentifierFromSchema, deleteObjectsUser, nil)
@@ -75,7 +76,7 @@ func getObjectsUserSchema(t SchemaType) map[string]*schema.Schema {
 	return m
 }
 
-func resourceCloudscaleObjectsUserCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func createObjectsUser(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*cloudscale.Client)
 
 	opts := &cloudscale.ObjectsUserRequest{

--- a/cloudscale/resource_cloudscale_objects_user.go
+++ b/cloudscale/resource_cloudscale_objects_user.go
@@ -20,8 +20,8 @@ func resourceCloudscaleObjectsUser() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceCloudscaleObjectsUserCreate,
 		Read:   resourceCloudscaleObjectsUserRead,
-		Update: resourceCloudscaleObjectsUserUpdate,
-		Delete: resourceCloudscaleObjectsUserDelete,
+		UpdateContext: resourceCloudscaleObjectsUserUpdate,
+		DeleteContext: resourceCloudscaleObjectsUserDelete,
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -123,9 +123,9 @@ func readObjectsUser(rId GenericResourceIdentifier, meta any) (*cloudscale.Objec
 	return client.ObjectsUsers.Get(context.Background(), rId.Id)
 }
 
-func updateObjectsUser(rId GenericResourceIdentifier, meta any, updateRequest *cloudscale.ObjectsUserRequest) error {
+func updateObjectsUser(ctx context.Context, rId GenericResourceIdentifier, meta any, updateRequest *cloudscale.ObjectsUserRequest) error {
 	client := meta.(*cloudscale.Client)
-	return client.ObjectsUsers.Update(context.Background(), rId.Id, updateRequest)
+	return client.ObjectsUsers.Update(ctx, rId.Id, updateRequest)
 }
 
 func gatherObjectsUserUpdateRequest(d *schema.ResourceData) []*cloudscale.ObjectsUserRequest {
@@ -146,7 +146,7 @@ func gatherObjectsUserUpdateRequest(d *schema.ResourceData) []*cloudscale.Object
 	return requests
 }
 
-func deleteObjectsUser(rId GenericResourceIdentifier, meta any) error {
+func deleteObjectsUser(ctx context.Context, rId GenericResourceIdentifier, meta any) error {
 	client := meta.(*cloudscale.Client)
-	return client.ObjectsUsers.Delete(context.Background(), rId.Id)
+	return client.ObjectsUsers.Delete(ctx, rId.Id)
 }

--- a/cloudscale/resource_cloudscale_objects_user.go
+++ b/cloudscale/resource_cloudscale_objects_user.go
@@ -12,8 +12,8 @@ const objectsUserHumanName = "Objects User"
 
 var (
 	resourceCloudscaleObjectsUserRead   = getReadOperation(objectsUserHumanName, getGenericResourceIdentifierFromSchema, readObjectsUser, gatherObjectsUserResourceData)
-	resourceCloudscaleObjectsUserUpdate = getUpdateOperation(objectsUserHumanName, getGenericResourceIdentifierFromSchema, updateObjectsUser, resourceCloudscaleObjectsUserRead, gatherObjectsUserUpdateRequest)
-	resourceCloudscaleObjectsUserDelete = getDeleteOperation(objectsUserHumanName, deleteObjectsUser)
+	resourceCloudscaleObjectsUserUpdate = getUpdateOperation(objectsUserHumanName, getGenericResourceIdentifierFromSchema, updateObjectsUser, resourceCloudscaleObjectsUserRead, gatherObjectsUserUpdateRequest, nil)
+	resourceCloudscaleObjectsUserDelete = getDeleteOperation(objectsUserHumanName, getGenericResourceIdentifierFromSchema, deleteObjectsUser, nil)
 )
 
 func resourceCloudscaleObjectsUser() *schema.Resource {
@@ -146,8 +146,7 @@ func gatherObjectsUserUpdateRequest(d *schema.ResourceData) []*cloudscale.Object
 	return requests
 }
 
-func deleteObjectsUser(d *schema.ResourceData, meta any) error {
+func deleteObjectsUser(rId GenericResourceIdentifier, meta any) error {
 	client := meta.(*cloudscale.Client)
-	id := d.Id()
-	return client.ObjectsUsers.Delete(context.Background(), id)
+	return client.ObjectsUsers.Delete(context.Background(), rId.Id)
 }

--- a/cloudscale/resource_cloudscale_server.go
+++ b/cloudscale/resource_cloudscale_server.go
@@ -14,8 +14,11 @@ import (
 
 const serverHumanName = "server"
 
-var resourceCloudscaleServerRead = getReadOperation(serverHumanName, getGenericResourceIdentifierFromSchema, readServer, gatherServerResourceData)
-var resourceCloudscaleServerDelete = getDeleteOperation(serverHumanName, getGenericResourceIdentifierFromSchema, deleteServer, nil)
+var (
+	resourceCloudscaleServerCreate = getCreateOperation(createServer, nil)
+	resourceCloudscaleServerRead   = getReadOperation(serverHumanName, getGenericResourceIdentifierFromSchema, readServer, gatherServerResourceData)
+	resourceCloudscaleServerDelete = getDeleteOperation(serverHumanName, getGenericResourceIdentifierFromSchema, deleteServer, nil)
+)
 
 func resourceCloudscaleServer() *schema.Resource {
 	return &schema.Resource{
@@ -289,7 +292,7 @@ func getServerSchema(t SchemaType) map[string]*schema.Schema {
 	return m
 }
 
-func resourceCloudscaleServerCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func createServer(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	timeout := d.Timeout(schema.TimeoutCreate)
 	startTime := time.Now()
 

--- a/cloudscale/resource_cloudscale_server.go
+++ b/cloudscale/resource_cloudscale_server.go
@@ -20,8 +20,8 @@ func resourceCloudscaleServer() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceCloudscaleServerCreate,
 		Read:   resourceCloudscaleServerRead,
-		Update: resourceCloudscaleServerUpdate,
-		Delete: resourceCloudscaleServerDelete,
+		Update:        resourceCloudscaleServerUpdate,
+		DeleteContext: resourceCloudscaleServerDelete,
 
 		Schema: getServerSchema(RESOURCE),
 		Timeouts: &schema.ResourceTimeout{
@@ -675,9 +675,9 @@ func resourceCloudscaleServerUpdate(d *schema.ResourceData, meta any) error {
 	return resourceCloudscaleServerRead(d, meta)
 }
 
-func deleteServer(rId GenericResourceIdentifier, meta any) error {
+func deleteServer(ctx context.Context, rId GenericResourceIdentifier, meta any) error {
 	client := meta.(*cloudscale.Client)
-	return client.Servers.Delete(context.Background(), rId.Id)
+	return client.Servers.Delete(ctx, rId.Id)
 }
 
 func newServerRefreshFunc(d *schema.ResourceData, attribute string, meta any) resource.StateRefreshFunc {

--- a/cloudscale/resource_cloudscale_server.go
+++ b/cloudscale/resource_cloudscale_server.go
@@ -14,7 +14,7 @@ import (
 const serverHumanName = "server"
 
 var resourceCloudscaleServerRead = getReadOperation(serverHumanName, getGenericResourceIdentifierFromSchema, readServer, gatherServerResourceData)
-var resourceCloudscaleServerDelete = getDeleteOperation(serverHumanName, deleteServer)
+var resourceCloudscaleServerDelete = getDeleteOperation(serverHumanName, getGenericResourceIdentifierFromSchema, deleteServer, nil)
 
 func resourceCloudscaleServer() *schema.Resource {
 	return &schema.Resource{
@@ -675,10 +675,9 @@ func resourceCloudscaleServerUpdate(d *schema.ResourceData, meta any) error {
 	return resourceCloudscaleServerRead(d, meta)
 }
 
-func deleteServer(d *schema.ResourceData, meta any) error {
+func deleteServer(rId GenericResourceIdentifier, meta any) error {
 	client := meta.(*cloudscale.Client)
-	id := d.Id()
-	return client.Servers.Delete(context.Background(), id)
+	return client.Servers.Delete(context.Background(), rId.Id)
 }
 
 func newServerRefreshFunc(d *schema.ResourceData, attribute string, meta any) resource.StateRefreshFunc {

--- a/cloudscale/resource_cloudscale_server.go
+++ b/cloudscale/resource_cloudscale_server.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/cloudscale-ch/cloudscale-go-sdk/v9"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -18,9 +19,9 @@ var resourceCloudscaleServerDelete = getDeleteOperation(serverHumanName, getGene
 
 func resourceCloudscaleServer() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceCloudscaleServerCreate,
-		Read:   resourceCloudscaleServerRead,
-		Update:        resourceCloudscaleServerUpdate,
+		CreateContext: resourceCloudscaleServerCreate,
+		ReadContext:   resourceCloudscaleServerRead,
+		UpdateContext: resourceCloudscaleServerUpdate,
 		DeleteContext: resourceCloudscaleServerDelete,
 
 		Schema: getServerSchema(RESOURCE),
@@ -288,7 +289,7 @@ func getServerSchema(t SchemaType) map[string]*schema.Schema {
 	return m
 }
 
-func resourceCloudscaleServerCreate(d *schema.ResourceData, meta any) error {
+func resourceCloudscaleServerCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	timeout := d.Timeout(schema.TimeoutCreate)
 	startTime := time.Now()
 
@@ -364,9 +365,9 @@ func resourceCloudscaleServerCreate(d *schema.ResourceData, meta any) error {
 
 	log.Printf("[DEBUG] Server create configuration: %#v", opts)
 
-	server, err := client.Servers.Create(context.Background(), opts)
+	server, err := client.Servers.Create(ctx, opts)
 	if err != nil {
-		return fmt.Errorf("Error creating server: %s", err)
+		return diag.FromErr(fmt.Errorf("Error creating server: %s", err))
 	}
 
 	d.SetId(server.UUID)
@@ -374,38 +375,34 @@ func resourceCloudscaleServerCreate(d *schema.ResourceData, meta any) error {
 	log.Printf("[INFO] Server ID %s", d.Id())
 
 	remainingTime := timeout - time.Since(startTime)
-	_, err = waitForStatus([]string{"changing"}, "running", &remainingTime, newServerRefreshFunc(d, "status", meta))
+	_, err = waitForStatus(ctx, []string{"changing"}, "running", &remainingTime, newServerRefreshFunc(ctx, d, "status", meta))
 	if err != nil {
-		return fmt.Errorf("error waiting for server (%s) to become ready: %s", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("error waiting for server (%s) to become ready: %s", d.Id(), err))
 	}
 
 	remainingTime = timeout - time.Since(startTime)
-	err = waitForSSHHostKeys(d, meta, &remainingTime)
+	err = waitForSSHHostKeys(ctx, d, meta, &remainingTime)
 	if err != nil {
-		return fmt.Errorf("error waiting for SSH host keys (%s) to be available: %s", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("error waiting for SSH host keys (%s) to be available: %s", d.Id(), err))
 	}
 
 	if originalStatus == "stopped" {
 		updateRequest := &cloudscale.ServerUpdateRequest{
 			Status: originalStatus,
 		}
-		err := client.Servers.Update(context.Background(), server.UUID, updateRequest)
+		err := client.Servers.Update(ctx, server.UUID, updateRequest)
 		if err != nil {
-			return fmt.Errorf("error stopping the server (%s) status (%s) ", server.UUID, err)
+			return diag.FromErr(fmt.Errorf("error stopping the server (%s) status (%s) ", server.UUID, err))
 		}
 
 		remainingTime = timeout - time.Since(startTime)
-		_, err = waitForStatus([]string{"changing", "running"}, "stopped", &remainingTime, newServerRefreshFunc(d, "status", meta))
+		_, err = waitForStatus(ctx, []string{"changing", "running"}, "stopped", &remainingTime, newServerRefreshFunc(ctx, d, "status", meta))
 		if err != nil {
-			return fmt.Errorf("error waiting for server status (%s) (%s) ", server.UUID, err)
+			return diag.FromErr(fmt.Errorf("error waiting for server status (%s) (%s) ", server.UUID, err))
 		}
 	}
 
-	err = resourceCloudscaleServerRead(d, meta)
-	if err != nil {
-		return fmt.Errorf("Error reading the server (%s): %s", d.Id(), err)
-	}
-	return nil
+	return resourceCloudscaleServerRead(ctx, d, meta)
 }
 
 func createImageOption(d *schema.ResourceData) string {
@@ -550,12 +547,12 @@ func gatherServerResourceData(server *cloudscale.Server) ResourceDataRaw {
 	return m
 }
 
-func readServer(rId GenericResourceIdentifier, meta any) (*cloudscale.Server, error) {
+func readServer(ctx context.Context, rId GenericResourceIdentifier, meta any) (*cloudscale.Server, error) {
 	client := meta.(*cloudscale.Client)
-	return client.Servers.Get(context.Background(), rId.Id)
+	return client.Servers.Get(ctx, rId.Id)
 }
 
-func resourceCloudscaleServerUpdate(d *schema.ResourceData, meta any) error {
+func resourceCloudscaleServerUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	timeout := d.Timeout(schema.TimeoutUpdate)
 	startTime := time.Now()
 	remainingTime := timeout - time.Since(startTime)
@@ -574,46 +571,46 @@ func resourceCloudscaleServerUpdate(d *schema.ResourceData, meta any) error {
 		// The root volume is the first volume.
 		volumeUUID := d.Get("volumes.0.uuid").(string)
 		opts := &cloudscale.VolumeUpdateRequest{SizeGB: d.Get("volume_size_gb").(int)}
-		err := client.Volumes.Update(context.Background(), volumeUUID, opts)
+		err := client.Volumes.Update(ctx, volumeUUID, opts)
 		if err != nil {
-			return fmt.Errorf("Error scaling the Volume (%s) status (%s) ", volumeUUID, err)
+			return diag.FromErr(fmt.Errorf("Error scaling the Volume (%s) status (%s) ", volumeUUID, err))
 		}
 	}
 
 	if d.HasChange("flavor_slug") {
 		if !d.Get("allow_stopping_for_update").(bool) {
-			return fmt.Errorf("Changing the flavor requires stopping the server. " +
-				"To acknowledge this, please set allow_stopping_for_update = true in your config.")
+			return diag.FromErr(fmt.Errorf("Changing the flavor requires stopping the server. " +
+				"To acknowledge this, please set allow_stopping_for_update = true in your config."))
 		}
 
-		server, err := client.Servers.Get(context.Background(), id)
+		server, err := client.Servers.Get(ctx, id)
 		if err != nil {
-			return fmt.Errorf("Error retrieving server (%s) for update %s", id, err)
+			return diag.FromErr(fmt.Errorf("Error retrieving server (%s) for update %s", id, err))
 		}
 		if server.Status != cloudscale.ServerStopped {
 			updateRequest := &cloudscale.ServerUpdateRequest{
 				Status: cloudscale.ServerStopped,
 			}
-			err := client.Servers.Update(context.Background(), id, updateRequest)
+			err := client.Servers.Update(ctx, id, updateRequest)
 			if err != nil {
-				return fmt.Errorf("Error updating server (%s), %s", server.Status, err)
+				return diag.FromErr(fmt.Errorf("Error updating server (%s), %s", server.Status, err))
 			}
 
 			remainingTime = timeout - time.Since(startTime)
-			_, err = waitForStatus([]string{"changing", "running"}, "stopped", &remainingTime, newServerRefreshFunc(d, "status", meta))
+			_, err = waitForStatus(ctx, []string{"changing", "running"}, "stopped", &remainingTime, newServerRefreshFunc(ctx, d, "status", meta))
 			if err != nil {
-				return fmt.Errorf("Error waiting for server (%s) to change status %s", d.Id(), err)
+				return diag.FromErr(fmt.Errorf("Error waiting for server (%s) to change status %s", d.Id(), err))
 			}
 		}
 
 		updateRequest := &cloudscale.ServerUpdateRequest{Flavor: wantedFlavor}
 
-		err = client.Servers.Update(context.Background(), id, updateRequest)
+		err = client.Servers.Update(ctx, id, updateRequest)
 		if err != nil {
-			return fmt.Errorf("Error scaling the Server (%s) status (%s) ", id, err)
+			return diag.FromErr(fmt.Errorf("Error scaling the Server (%s) status (%s) ", id, err))
 		}
 		remainingTime = timeout - time.Since(startTime)
-		_, err = waitForStatus([]string{"changing"}, "stopped", &remainingTime, newServerRefreshFunc(d, "status", meta))
+		_, err = waitForStatus(ctx, []string{"changing"}, "stopped", &remainingTime, newServerRefreshFunc(ctx, d, "status", meta))
 
 		// Signal that we want to start the server again
 		if wantedStatus == "running" {
@@ -625,54 +622,54 @@ func resourceCloudscaleServerUpdate(d *schema.ResourceData, meta any) error {
 		updateRequest := &cloudscale.ServerUpdateRequest{
 			Status: wantedStatus,
 		}
-		err := client.Servers.Update(context.Background(), id, updateRequest)
+		err := client.Servers.Update(ctx, id, updateRequest)
 		if err != nil {
-			return fmt.Errorf("Error changing status (%s) (%s) ", id, err)
+			return diag.FromErr(fmt.Errorf("Error changing status (%s) (%s) ", id, err))
 		}
 
 		if wantedStatus == "rebooted" {
-			return fmt.Errorf("Status (%s) not supported", wantedStatus)
+			return diag.FromErr(fmt.Errorf("Status (%s) not supported", wantedStatus))
 		}
 
 		remainingTime = timeout - time.Since(startTime)
 		if wantedStatus == "stopped" {
-			_, err = waitForStatus([]string{"changing", "running"}, "stopped", &remainingTime, newServerRefreshFunc(d, "status", meta))
+			_, err = waitForStatus(ctx, []string{"changing", "running"}, "stopped", &remainingTime, newServerRefreshFunc(ctx, d, "status", meta))
 		} else {
-			_, err = waitForStatus([]string{"changing", "stopped"}, "running", &remainingTime, newServerRefreshFunc(d, "status", meta))
+			_, err = waitForStatus(ctx, []string{"changing", "stopped"}, "running", &remainingTime, newServerRefreshFunc(ctx, d, "status", meta))
 		}
 
 		if err != nil {
-			return fmt.Errorf("Error waiting for server (%s) to change status %s", d.Id(), err)
+			return diag.FromErr(fmt.Errorf("Error waiting for server (%s) to change status %s", d.Id(), err))
 		}
 	}
 
 	if d.HasChange("name") {
 		updateRequest := &cloudscale.ServerUpdateRequest{Name: wantedName}
-		err := client.Servers.Update(context.Background(), id, updateRequest)
+		err := client.Servers.Update(ctx, id, updateRequest)
 		if err != nil {
-			return fmt.Errorf("Error renaming the Server (%s) status (%s) ", id, err)
+			return diag.FromErr(fmt.Errorf("Error renaming the Server (%s) status (%s) ", id, err))
 		}
 	}
 
 	if d.HasChange("interfaces") {
 		interfaceRequests := createInterfaceOptions(d)
 		updateRequest := &cloudscale.ServerUpdateRequest{Interfaces: &interfaceRequests}
-		err := client.Servers.Update(context.Background(), id, updateRequest)
+		err := client.Servers.Update(ctx, id, updateRequest)
 		if err != nil {
-			return fmt.Errorf("Error changing the Server (%s) interfaces (%s) ", id, err)
+			return diag.FromErr(fmt.Errorf("Error changing the Server (%s) interfaces (%s) ", id, err))
 		}
 	}
 
 	if d.HasChange("tags") {
 		updateRequest := &cloudscale.ServerUpdateRequest{}
 		updateRequest.Tags = CopyTags(d)
-		err := client.Servers.Update(context.Background(), id, updateRequest)
+		err := client.Servers.Update(ctx, id, updateRequest)
 		if err != nil {
-			return fmt.Errorf("Error tagging the Server (%s) status (%s) ", id, err)
+			return diag.FromErr(fmt.Errorf("Error tagging the Server (%s) status (%s) ", id, err))
 		}
 	}
 
-	return resourceCloudscaleServerRead(d, meta)
+	return resourceCloudscaleServerRead(ctx, d, meta)
 }
 
 func deleteServer(ctx context.Context, rId GenericResourceIdentifier, meta any) error {
@@ -680,13 +677,13 @@ func deleteServer(ctx context.Context, rId GenericResourceIdentifier, meta any) 
 	return client.Servers.Delete(ctx, rId.Id)
 }
 
-func newServerRefreshFunc(d *schema.ResourceData, attribute string, meta any) resource.StateRefreshFunc {
+func newServerRefreshFunc(ctx context.Context, d *schema.ResourceData, attribute string, meta any) resource.StateRefreshFunc {
 	client := meta.(*cloudscale.Client)
 	return func() (any, string, error) {
 		id := d.Id()
 
 		// get the instance
-		server, err := client.Servers.Get(context.Background(), id)
+		server, err := client.Servers.Get(ctx, id)
 		if err != nil {
 			return nil, "", fmt.Errorf("error retrieving server (%s) (refresh) %s", id, err)
 		}
@@ -702,18 +699,18 @@ func newServerRefreshFunc(d *schema.ResourceData, attribute string, meta any) re
 	}
 }
 
-func waitForSSHHostKeys(d *schema.ResourceData, meta any, timeout *time.Duration) error {
+func waitForSSHHostKeys(ctx context.Context, d *schema.ResourceData, meta any, timeout *time.Duration) error {
 	if d.Get("skip_waiting_for_ssh_host_keys").(bool) {
 		log.Printf("[INFO] Not waiting for server (%s) to have host keys available", d.Id())
 		return nil
 	}
 	log.Printf("[INFO] Waiting %s for server (%s) to have host keys available", timeout, d.Id())
 
-	err := resource.Retry(*timeout, func() *resource.RetryError {
-		err := resourceCloudscaleServerRead(d, meta)
-		if err != nil {
+	err := resource.RetryContext(ctx, *timeout, func() *resource.RetryError {
+		diags := resourceCloudscaleServerRead(ctx, d, meta)
+		if diags.HasError() {
 			return &resource.RetryError{
-				Err:       err,
+				Err:       fmt.Errorf("error reading server (%s): %s", d.Id(), diags[0].Summary),
 				Retryable: false,
 			}
 		}

--- a/cloudscale/resource_cloudscale_server_group.go
+++ b/cloudscale/resource_cloudscale_server_group.go
@@ -13,8 +13,8 @@ const serverGroupHumanName = "server group"
 
 var (
 	resourceCloudscaleServerGroupRead   = getReadOperation(serverGroupHumanName, getGenericResourceIdentifierFromSchema, readServerGroup, gatherServerGroupResourceData)
-	resourceCloudscaleServerGroupUpdate = getUpdateOperation(serverGroupHumanName, getGenericResourceIdentifierFromSchema, updateServerGroup, resourceCloudscaleServerGroupRead, gatherServerGroupUpdateRequest)
-	resourceCloudscaleServerGroupDelete = getDeleteOperation(serverGroupHumanName, deleteServerGroup)
+	resourceCloudscaleServerGroupUpdate = getUpdateOperation(serverGroupHumanName, getGenericResourceIdentifierFromSchema, updateServerGroup, resourceCloudscaleServerGroupRead, gatherServerGroupUpdateRequest, nil)
+	resourceCloudscaleServerGroupDelete = getDeleteOperation(serverGroupHumanName, getGenericResourceIdentifierFromSchema, deleteServerGroup, nil)
 )
 
 func resourceCloudscaleServerGroup() *schema.Resource {
@@ -136,8 +136,7 @@ func gatherServerGroupUpdateRequest(d *schema.ResourceData) []*cloudscale.Server
 	return requests
 }
 
-func deleteServerGroup(d *schema.ResourceData, meta any) error {
+func deleteServerGroup(rId GenericResourceIdentifier, meta any) error {
 	client := meta.(*cloudscale.Client)
-	id := d.Id()
-	return client.ServerGroups.Delete(context.Background(), id)
+	return client.ServerGroups.Delete(context.Background(), rId.Id)
 }

--- a/cloudscale/resource_cloudscale_server_group.go
+++ b/cloudscale/resource_cloudscale_server_group.go
@@ -6,6 +6,7 @@ import (
 	"log"
 
 	"github.com/cloudscale-ch/cloudscale-go-sdk/v9"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -19,8 +20,8 @@ var (
 
 func resourceCloudscaleServerGroup() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceCloudscaleServerGroupCreate,
-		Read:   resourceCloudscaleServerGroupRead,
+		CreateContext: resourceCloudscaleServerGroupCreate,
+		ReadContext:   resourceCloudscaleServerGroupRead,
 		UpdateContext: resourceCloudscaleServerGroupUpdate,
 		DeleteContext: resourceCloudscaleServerGroupDelete,
 
@@ -65,7 +66,7 @@ func getServerGroupSchema(t SchemaType) map[string]*schema.Schema {
 	return m
 }
 
-func resourceCloudscaleServerGroupCreate(d *schema.ResourceData, meta any) error {
+func resourceCloudscaleServerGroupCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*cloudscale.Client)
 
 	opts := &cloudscale.ServerGroupRequest{
@@ -80,20 +81,16 @@ func resourceCloudscaleServerGroupCreate(d *schema.ResourceData, meta any) error
 
 	log.Printf("[DEBUG] ServerGroup create configuration: %#v", opts)
 
-	serverGroup, err := client.ServerGroups.Create(context.Background(), opts)
+	serverGroup, err := client.ServerGroups.Create(ctx, opts)
 	if err != nil {
-		return fmt.Errorf("Error creating server group: %s", err)
+		return diag.FromErr(fmt.Errorf("Error creating server group: %s", err))
 	}
 
 	d.SetId(serverGroup.UUID)
 
 	log.Printf("[INFO] ServerGroup ID %s", d.Id())
 
-	err = resourceCloudscaleServerGroupRead(d, meta)
-	if err != nil {
-		return fmt.Errorf("Error reading the server group (%s): %s", d.Id(), err)
-	}
-	return nil
+	return resourceCloudscaleServerGroupRead(ctx, d, meta)
 }
 
 func gatherServerGroupResourceData(serverGroup *cloudscale.ServerGroup) ResourceDataRaw {
@@ -107,9 +104,9 @@ func gatherServerGroupResourceData(serverGroup *cloudscale.ServerGroup) Resource
 	return m
 }
 
-func readServerGroup(rId GenericResourceIdentifier, meta any) (*cloudscale.ServerGroup, error) {
+func readServerGroup(ctx context.Context, rId GenericResourceIdentifier, meta any) (*cloudscale.ServerGroup, error) {
 	client := meta.(*cloudscale.Client)
-	return client.ServerGroups.Get(context.Background(), rId.Id)
+	return client.ServerGroups.Get(ctx, rId.Id)
 }
 
 func updateServerGroup(ctx context.Context, rId GenericResourceIdentifier, meta any, updateRequest *cloudscale.ServerGroupRequest) error {

--- a/cloudscale/resource_cloudscale_server_group.go
+++ b/cloudscale/resource_cloudscale_server_group.go
@@ -13,6 +13,7 @@ import (
 const serverGroupHumanName = "server group"
 
 var (
+	resourceCloudscaleServerGroupCreate = getCreateOperation(createServerGroup, nil)
 	resourceCloudscaleServerGroupRead   = getReadOperation(serverGroupHumanName, getGenericResourceIdentifierFromSchema, readServerGroup, gatherServerGroupResourceData)
 	resourceCloudscaleServerGroupUpdate = getUpdateOperation(serverGroupHumanName, getGenericResourceIdentifierFromSchema, updateServerGroup, resourceCloudscaleServerGroupRead, gatherServerGroupUpdateRequest, nil)
 	resourceCloudscaleServerGroupDelete = getDeleteOperation(serverGroupHumanName, getGenericResourceIdentifierFromSchema, deleteServerGroup, nil)
@@ -66,7 +67,7 @@ func getServerGroupSchema(t SchemaType) map[string]*schema.Schema {
 	return m
 }
 
-func resourceCloudscaleServerGroupCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func createServerGroup(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*cloudscale.Client)
 
 	opts := &cloudscale.ServerGroupRequest{

--- a/cloudscale/resource_cloudscale_server_group.go
+++ b/cloudscale/resource_cloudscale_server_group.go
@@ -21,8 +21,8 @@ func resourceCloudscaleServerGroup() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceCloudscaleServerGroupCreate,
 		Read:   resourceCloudscaleServerGroupRead,
-		Update: resourceCloudscaleServerGroupUpdate,
-		Delete: resourceCloudscaleServerGroupDelete,
+		UpdateContext: resourceCloudscaleServerGroupUpdate,
+		DeleteContext: resourceCloudscaleServerGroupDelete,
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -112,9 +112,9 @@ func readServerGroup(rId GenericResourceIdentifier, meta any) (*cloudscale.Serve
 	return client.ServerGroups.Get(context.Background(), rId.Id)
 }
 
-func updateServerGroup(rId GenericResourceIdentifier, meta any, updateRequest *cloudscale.ServerGroupRequest) error {
+func updateServerGroup(ctx context.Context, rId GenericResourceIdentifier, meta any, updateRequest *cloudscale.ServerGroupRequest) error {
 	client := meta.(*cloudscale.Client)
-	return client.ServerGroups.Update(context.Background(), rId.Id, updateRequest)
+	return client.ServerGroups.Update(ctx, rId.Id, updateRequest)
 }
 
 func gatherServerGroupUpdateRequest(d *schema.ResourceData) []*cloudscale.ServerGroupRequest {
@@ -136,7 +136,7 @@ func gatherServerGroupUpdateRequest(d *schema.ResourceData) []*cloudscale.Server
 	return requests
 }
 
-func deleteServerGroup(rId GenericResourceIdentifier, meta any) error {
+func deleteServerGroup(ctx context.Context, rId GenericResourceIdentifier, meta any) error {
 	client := meta.(*cloudscale.Client)
-	return client.ServerGroups.Delete(context.Background(), rId.Id)
+	return client.ServerGroups.Delete(ctx, rId.Id)
 }

--- a/cloudscale/resource_cloudscale_subnet.go
+++ b/cloudscale/resource_cloudscale_subnet.go
@@ -14,6 +14,7 @@ import (
 const subnetHumanName = "subnet"
 
 var (
+	resourceCloudscaleSubnetCreate = getCreateOperation(createSubnet, nil)
 	resourceCloudscaleSubnetRead   = getReadOperation(subnetHumanName, getGenericResourceIdentifierFromSchema, readSubnet, gatherSubnetResourceData)
 	resourceCloudscaleSubnetUpdate = getUpdateOperation(subnetHumanName, getGenericResourceIdentifierFromSchema, updateSubnet, resourceCloudscaleSubnetRead, gatherSubnetUpdateRequests, nil)
 	resourceCloudscaleSubnetDelete = getDeleteOperation(subnetHumanName, getGenericResourceIdentifierFromSchema, deleteSubnet, nil)
@@ -88,7 +89,7 @@ func getSubnetSchema(t SchemaType) map[string]*schema.Schema {
 	return m
 }
 
-func resourceCloudscaleSubnetCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func createSubnet(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*cloudscale.Client)
 
 	opts := &cloudscale.SubnetCreateRequest{

--- a/cloudscale/resource_cloudscale_subnet.go
+++ b/cloudscale/resource_cloudscale_subnet.go
@@ -22,8 +22,8 @@ func resourceCloudscaleSubnet() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceCloudscaleSubnetCreate,
 		Read:   resourceCloudscaleSubnetRead,
-		Update: resourceCloudscaleSubnetUpdate,
-		Delete: resourceCloudscaleSubnetDelete,
+		UpdateContext: resourceCloudscaleSubnetUpdate,
+		DeleteContext: resourceCloudscaleSubnetDelete,
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -157,9 +157,9 @@ func readSubnet(rId GenericResourceIdentifier, meta any) (*cloudscale.Subnet, er
 	return client.Subnets.Get(context.Background(), rId.Id)
 }
 
-func updateSubnet(rId GenericResourceIdentifier, meta any, updateRequest *cloudscale.SubnetUpdateRequest) error {
+func updateSubnet(ctx context.Context, rId GenericResourceIdentifier, meta any, updateRequest *cloudscale.SubnetUpdateRequest) error {
 	client := meta.(*cloudscale.Client)
-	return client.Subnets.Update(context.Background(), rId.Id, updateRequest)
+	return client.Subnets.Update(ctx, rId.Id, updateRequest)
 }
 
 func gatherSubnetUpdateRequests(d *schema.ResourceData) []*cloudscale.SubnetUpdateRequest {
@@ -197,9 +197,9 @@ func gatherSubnetUpdateRequests(d *schema.ResourceData) []*cloudscale.SubnetUpda
 	return requests
 }
 
-func deleteSubnet(rId GenericResourceIdentifier, meta any) error {
+func deleteSubnet(ctx context.Context, rId GenericResourceIdentifier, meta any) error {
 	client := meta.(*cloudscale.Client)
 	// sending the next request immediately can cause errors, since the port cleanup process is still ongoing
 	time.Sleep(5 * time.Second)
-	return client.Subnets.Delete(context.Background(), rId.Id)
+	return client.Subnets.Delete(ctx, rId.Id)
 }

--- a/cloudscale/resource_cloudscale_subnet.go
+++ b/cloudscale/resource_cloudscale_subnet.go
@@ -14,8 +14,8 @@ const subnetHumanName = "subnet"
 
 var (
 	resourceCloudscaleSubnetRead   = getReadOperation(subnetHumanName, getGenericResourceIdentifierFromSchema, readSubnet, gatherSubnetResourceData)
-	resourceCloudscaleSubnetUpdate = getUpdateOperation(subnetHumanName, getGenericResourceIdentifierFromSchema, updateSubnet, resourceCloudscaleSubnetRead, gatherSubnetUpdateRequests)
-	resourceCloudscaleSubnetDelete = getDeleteOperation(subnetHumanName, deleteSubnet)
+	resourceCloudscaleSubnetUpdate = getUpdateOperation(subnetHumanName, getGenericResourceIdentifierFromSchema, updateSubnet, resourceCloudscaleSubnetRead, gatherSubnetUpdateRequests, nil)
+	resourceCloudscaleSubnetDelete = getDeleteOperation(subnetHumanName, getGenericResourceIdentifierFromSchema, deleteSubnet, nil)
 )
 
 func resourceCloudscaleSubnet() *schema.Resource {
@@ -197,10 +197,9 @@ func gatherSubnetUpdateRequests(d *schema.ResourceData) []*cloudscale.SubnetUpda
 	return requests
 }
 
-func deleteSubnet(d *schema.ResourceData, meta any) error {
+func deleteSubnet(rId GenericResourceIdentifier, meta any) error {
 	client := meta.(*cloudscale.Client)
-	id := d.Id()
 	// sending the next request immediately can cause errors, since the port cleanup process is still ongoing
 	time.Sleep(5 * time.Second)
-	return client.Subnets.Delete(context.Background(), id)
+	return client.Subnets.Delete(context.Background(), rId.Id)
 }

--- a/cloudscale/resource_cloudscale_subnet.go
+++ b/cloudscale/resource_cloudscale_subnet.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/cloudscale-ch/cloudscale-go-sdk/v9"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -20,8 +21,8 @@ var (
 
 func resourceCloudscaleSubnet() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceCloudscaleSubnetCreate,
-		Read:   resourceCloudscaleSubnetRead,
+		CreateContext: resourceCloudscaleSubnetCreate,
+		ReadContext:   resourceCloudscaleSubnetRead,
 		UpdateContext: resourceCloudscaleSubnetUpdate,
 		DeleteContext: resourceCloudscaleSubnetDelete,
 
@@ -87,7 +88,7 @@ func getSubnetSchema(t SchemaType) map[string]*schema.Schema {
 	return m
 }
 
-func resourceCloudscaleSubnetCreate(d *schema.ResourceData, meta any) error {
+func resourceCloudscaleSubnetCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*cloudscale.Client)
 
 	opts := &cloudscale.SubnetCreateRequest{
@@ -121,21 +122,16 @@ func resourceCloudscaleSubnetCreate(d *schema.ResourceData, meta any) error {
 
 	log.Printf("[DEBUG] Subnet create configuration: %#v", opts)
 
-	subnet, err := client.Subnets.Create(context.Background(), opts)
+	subnet, err := client.Subnets.Create(ctx, opts)
 	if err != nil {
-		return fmt.Errorf("Error creating subnet: %s", err)
+		return diag.FromErr(fmt.Errorf("Error creating subnet: %s", err))
 	}
 
 	d.SetId(subnet.UUID)
 
 	log.Printf("[INFO] Subnet ID %s", d.Id())
 
-	err = resourceCloudscaleSubnetRead(d, meta)
-	if err != nil {
-		return fmt.Errorf("Error reading the subnet (%s): %s", d.Id(), err)
-	}
-
-	return nil
+	return resourceCloudscaleSubnetRead(ctx, d, meta)
 }
 
 func gatherSubnetResourceData(subnet *cloudscale.Subnet) ResourceDataRaw {
@@ -152,9 +148,9 @@ func gatherSubnetResourceData(subnet *cloudscale.Subnet) ResourceDataRaw {
 	return m
 }
 
-func readSubnet(rId GenericResourceIdentifier, meta any) (*cloudscale.Subnet, error) {
+func readSubnet(ctx context.Context, rId GenericResourceIdentifier, meta any) (*cloudscale.Subnet, error) {
 	client := meta.(*cloudscale.Client)
-	return client.Subnets.Get(context.Background(), rId.Id)
+	return client.Subnets.Get(ctx, rId.Id)
 }
 
 func updateSubnet(ctx context.Context, rId GenericResourceIdentifier, meta any, updateRequest *cloudscale.SubnetUpdateRequest) error {

--- a/cloudscale/resource_cloudscale_volume.go
+++ b/cloudscale/resource_cloudscale_volume.go
@@ -21,8 +21,8 @@ func resourceCloudscaleVolume() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceCloudscaleVolumeCreate,
 		Read:   resourceCloudscaleVolumeRead,
-		Update: resourceCloudscaleVolumeUpdate,
-		Delete: resourceCloudscaleVolumeDelete,
+		UpdateContext: resourceCloudscaleVolumeUpdate,
+		DeleteContext: resourceCloudscaleVolumeDelete,
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -195,9 +195,9 @@ func readVolume(rId GenericResourceIdentifier, meta any) (*cloudscale.Volume, er
 	return client.Volumes.Get(context.Background(), rId.Id)
 }
 
-func updateVolume(rId GenericResourceIdentifier, meta any, updateRequest *cloudscale.VolumeUpdateRequest) error {
+func updateVolume(ctx context.Context, rId GenericResourceIdentifier, meta any, updateRequest *cloudscale.VolumeUpdateRequest) error {
 	client := meta.(*cloudscale.Client)
-	return client.Volumes.Update(context.Background(), rId.Id, updateRequest)
+	return client.Volumes.Update(ctx, rId.Id, updateRequest)
 }
 
 func gatherVolumeUpdateRequests(d *schema.ResourceData) []*cloudscale.VolumeUpdateRequest {
@@ -229,7 +229,7 @@ func gatherVolumeUpdateRequests(d *schema.ResourceData) []*cloudscale.VolumeUpda
 	return requests
 }
 
-func deleteVolume(rId GenericResourceIdentifier, meta any) error {
+func deleteVolume(ctx context.Context, rId GenericResourceIdentifier, meta any) error {
 	client := meta.(*cloudscale.Client)
-	return client.Volumes.Delete(context.Background(), rId.Id)
+	return client.Volumes.Delete(ctx, rId.Id)
 }

--- a/cloudscale/resource_cloudscale_volume.go
+++ b/cloudscale/resource_cloudscale_volume.go
@@ -13,6 +13,7 @@ import (
 const volumeHumanName = "volume"
 
 var (
+	resourceCloudscaleVolumeCreate = getCreateOperation(createVolume, nil)
 	resourceCloudscaleVolumeRead   = getReadOperation(volumeHumanName, getGenericResourceIdentifierFromSchema, readVolume, gatherVolumeResourceData)
 	resourceCloudscaleVolumeUpdate = getUpdateOperation(volumeHumanName, getGenericResourceIdentifierFromSchema, updateVolume, resourceCloudscaleVolumeRead, gatherVolumeUpdateRequests, nil)
 	resourceCloudscaleVolumeDelete = getDeleteOperation(volumeHumanName, getGenericResourceIdentifierFromSchema, deleteVolume, nil)
@@ -103,7 +104,7 @@ func getVolumeSchema(t SchemaType) map[string]*schema.Schema {
 	return m
 }
 
-func resourceCloudscaleVolumeCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func createVolume(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*cloudscale.Client)
 
 	opts := &cloudscale.VolumeCreateRequest{

--- a/cloudscale/resource_cloudscale_volume.go
+++ b/cloudscale/resource_cloudscale_volume.go
@@ -6,6 +6,7 @@ import (
 	"log"
 
 	"github.com/cloudscale-ch/cloudscale-go-sdk/v9"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -19,8 +20,8 @@ var (
 
 func resourceCloudscaleVolume() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceCloudscaleVolumeCreate,
-		Read:   resourceCloudscaleVolumeRead,
+		CreateContext: resourceCloudscaleVolumeCreate,
+		ReadContext:   resourceCloudscaleVolumeRead,
 		UpdateContext: resourceCloudscaleVolumeUpdate,
 		DeleteContext: resourceCloudscaleVolumeDelete,
 
@@ -102,7 +103,7 @@ func getVolumeSchema(t SchemaType) map[string]*schema.Schema {
 	return m
 }
 
-func resourceCloudscaleVolumeCreate(d *schema.ResourceData, meta any) error {
+func resourceCloudscaleVolumeCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*cloudscale.Client)
 
 	opts := &cloudscale.VolumeCreateRequest{
@@ -136,9 +137,9 @@ func resourceCloudscaleVolumeCreate(d *schema.ResourceData, meta any) error {
 
 	log.Printf("[DEBUG] Volume create configuration: %#v", opts)
 
-	volume, err := client.Volumes.Create(context.Background(), opts)
+	volume, err := client.Volumes.Create(ctx, opts)
 	if err != nil {
-		return fmt.Errorf("Error creating volume: %s", err)
+		return diag.FromErr(fmt.Errorf("Error creating volume: %s", err))
 	}
 
 	d.SetId(volume.UUID)
@@ -150,8 +151,8 @@ func resourceCloudscaleVolumeCreate(d *schema.ResourceData, meta any) error {
 			if sizeGB != volume.SizeGB {
 				log.Printf("[INFO] Resizing volume %s to %d GB after creation from snapshot", volume.UUID, sizeGB)
 				updateReq := &cloudscale.VolumeUpdateRequest{SizeGB: sizeGB}
-				if err := client.Volumes.Update(context.Background(), volume.UUID, updateReq); err != nil {
-					return fmt.Errorf("Error resizing volume (%s) after creation from snapshot: %s", volume.UUID, err)
+				if err := client.Volumes.Update(ctx, volume.UUID, updateReq); err != nil {
+					return diag.FromErr(fmt.Errorf("Error resizing volume (%s) after creation from snapshot: %s", volume.UUID, err))
 				}
 			}
 		}
@@ -164,17 +165,13 @@ func resourceCloudscaleVolumeCreate(d *schema.ResourceData, meta any) error {
 				s[i] = serverUUIDs[i].(string)
 			}
 			updateReq := &cloudscale.VolumeUpdateRequest{ServerUUIDs: &s}
-			if err := client.Volumes.Update(context.Background(), volume.UUID, updateReq); err != nil {
-				return fmt.Errorf("Error attaching volume (%s) after creation from snapshot: %s", volume.UUID, err)
+			if err := client.Volumes.Update(ctx, volume.UUID, updateReq); err != nil {
+				return diag.FromErr(fmt.Errorf("Error attaching volume (%s) after creation from snapshot: %s", volume.UUID, err))
 			}
 		}
 	}
 
-	err = resourceCloudscaleVolumeRead(d, meta)
-	if err != nil {
-		return fmt.Errorf("Error reading the volume (%s): %s", d.Id(), err)
-	}
-	return nil
+	return resourceCloudscaleVolumeRead(ctx, d, meta)
 }
 
 func gatherVolumeResourceData(volume *cloudscale.Volume) ResourceDataRaw {
@@ -190,9 +187,9 @@ func gatherVolumeResourceData(volume *cloudscale.Volume) ResourceDataRaw {
 	return m
 }
 
-func readVolume(rId GenericResourceIdentifier, meta any) (*cloudscale.Volume, error) {
+func readVolume(ctx context.Context, rId GenericResourceIdentifier, meta any) (*cloudscale.Volume, error) {
 	client := meta.(*cloudscale.Client)
-	return client.Volumes.Get(context.Background(), rId.Id)
+	return client.Volumes.Get(ctx, rId.Id)
 }
 
 func updateVolume(ctx context.Context, rId GenericResourceIdentifier, meta any, updateRequest *cloudscale.VolumeUpdateRequest) error {

--- a/cloudscale/resource_cloudscale_volume.go
+++ b/cloudscale/resource_cloudscale_volume.go
@@ -13,8 +13,8 @@ const volumeHumanName = "volume"
 
 var (
 	resourceCloudscaleVolumeRead   = getReadOperation(volumeHumanName, getGenericResourceIdentifierFromSchema, readVolume, gatherVolumeResourceData)
-	resourceCloudscaleVolumeUpdate = getUpdateOperation(volumeHumanName, getGenericResourceIdentifierFromSchema, updateVolume, resourceCloudscaleVolumeRead, gatherVolumeUpdateRequests)
-	resourceCloudscaleVolumeDelete = getDeleteOperation(volumeHumanName, deleteVolume)
+	resourceCloudscaleVolumeUpdate = getUpdateOperation(volumeHumanName, getGenericResourceIdentifierFromSchema, updateVolume, resourceCloudscaleVolumeRead, gatherVolumeUpdateRequests, nil)
+	resourceCloudscaleVolumeDelete = getDeleteOperation(volumeHumanName, getGenericResourceIdentifierFromSchema, deleteVolume, nil)
 )
 
 func resourceCloudscaleVolume() *schema.Resource {
@@ -229,8 +229,7 @@ func gatherVolumeUpdateRequests(d *schema.ResourceData) []*cloudscale.VolumeUpda
 	return requests
 }
 
-func deleteVolume(d *schema.ResourceData, meta any) error {
+func deleteVolume(rId GenericResourceIdentifier, meta any) error {
 	client := meta.(*cloudscale.Client)
-	id := d.Id()
-	return client.Volumes.Delete(context.Background(), id)
+	return client.Volumes.Delete(context.Background(), rId.Id)
 }

--- a/cloudscale/resource_cloudscale_volume_snapshot.go
+++ b/cloudscale/resource_cloudscale_volume_snapshot.go
@@ -21,21 +21,21 @@ func snapshotLockKey(volumeUUID string) string {
 
 // volumeSnapshotLockKey serializes snapshot operations on their source volume. The
 // cloudscale API rejects concurrent snapshot operations on the same source volume, so
-// create/update/delete are serialized per volume UUID. Because withLock wraps the
-// whole operation, the lock is held through the full create/delete status-wait cycle
-// (see resourceCloudscaleVolumeSnapshotCreate / deleteVolumeSnapshot), ensuring the
-// volume is no longer busy before the next operation on it starts.
+// create/update/delete are serialized per volume UUID. The lock is held through the
+// full create/delete status-wait cycle (see createVolumeSnapshot / deleteVolumeSnapshot),
+// ensuring the volume is no longer busy before the next operation on it starts.
 var volumeSnapshotLockKey = uuidLockKey("source_volume_uuid", snapshotLockKey)
 
 var (
 	resourceCloudscaleVolumeSnapshotRead   = getReadOperation(volumeSnapshotHumanName, getGenericResourceIdentifierFromSchema, readVolumeSnapshot, gatherVolumeSnapshotResourceData)
+	resourceCloudscaleVolumeSnapshotCreate = getCreateOperation(createVolumeSnapshot, volumeSnapshotLockKey)
 	resourceCloudscaleVolumeSnapshotUpdate = getUpdateOperation(volumeSnapshotHumanName, getGenericResourceIdentifierFromSchema, updateVolumeSnapshot, resourceCloudscaleVolumeSnapshotRead, gatherVolumeSnapshotUpdateRequest, volumeSnapshotLockKey)
 	resourceCloudscaleVolumeSnapshotDelete = getDeleteOperation(volumeSnapshotHumanName, getGenericResourceIdentifierFromSchema, deleteVolumeSnapshot, volumeSnapshotLockKey)
 )
 
 func resourceCloudscaleVolumeSnapshot() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: withLock(volumeSnapshotLockKey, resourceCloudscaleVolumeSnapshotCreate),
+		CreateContext: resourceCloudscaleVolumeSnapshotCreate,
 		ReadContext:   resourceCloudscaleVolumeSnapshotRead,
 		UpdateContext: resourceCloudscaleVolumeSnapshotUpdate,
 		DeleteContext: resourceCloudscaleVolumeSnapshotDelete,
@@ -92,7 +92,7 @@ func getVolumeSnapshotSchema(t SchemaType) map[string]*schema.Schema {
 	return m
 }
 
-func resourceCloudscaleVolumeSnapshotCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func createVolumeSnapshot(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	timeout := d.Timeout(schema.TimeoutCreate)
 	startTime := time.Now()
 

--- a/cloudscale/resource_cloudscale_volume_snapshot.go
+++ b/cloudscale/resource_cloudscale_volume_snapshot.go
@@ -38,7 +38,7 @@ var (
 func resourceCloudscaleVolumeSnapshot() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: withLock(volumeSnapshotLockKey, resourceCloudscaleVolumeSnapshotCreate),
-		Read:          resourceCloudscaleVolumeSnapshotRead,
+		ReadContext:   resourceCloudscaleVolumeSnapshotRead,
 		UpdateContext: resourceCloudscaleVolumeSnapshotUpdate,
 		DeleteContext: resourceCloudscaleVolumeSnapshotDelete,
 
@@ -125,7 +125,7 @@ func resourceCloudscaleVolumeSnapshotCreate(ctx context.Context, d *schema.Resou
 		return diag.FromErr(fmt.Errorf("error waiting for volume snapshot (%s) to become available: %s", d.Id(), err))
 	}
 
-	return diag.FromErr(resourceCloudscaleVolumeSnapshotRead(d, meta))
+	return resourceCloudscaleVolumeSnapshotRead(ctx, d, meta)
 }
 
 func newVolumeSnapshotRefreshFunc(ctx context.Context, d *schema.ResourceData, attribute string, meta any) resource.StateRefreshFunc {
@@ -164,9 +164,9 @@ func gatherVolumeSnapshotResourceData(snap *cloudscale.VolumeSnapshot) ResourceD
 	return m
 }
 
-func readVolumeSnapshot(rId GenericResourceIdentifier, meta any) (*cloudscale.VolumeSnapshot, error) {
+func readVolumeSnapshot(ctx context.Context, rId GenericResourceIdentifier, meta any) (*cloudscale.VolumeSnapshot, error) {
 	client := meta.(*cloudscale.Client)
-	return client.VolumeSnapshots.Get(context.Background(), rId.Id)
+	return client.VolumeSnapshots.Get(ctx, rId.Id)
 }
 
 func updateVolumeSnapshot(ctx context.Context, rId GenericResourceIdentifier, meta any, updateRequest *cloudscale.VolumeSnapshotUpdateRequest) error {

--- a/cloudscale/resource_cloudscale_volume_snapshot.go
+++ b/cloudscale/resource_cloudscale_volume_snapshot.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/cloudscale-ch/cloudscale-go-sdk/v9"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -36,10 +37,10 @@ var (
 
 func resourceCloudscaleVolumeSnapshot() *schema.Resource {
 	return &schema.Resource{
-		Create: withLock(volumeSnapshotLockKey, resourceCloudscaleVolumeSnapshotCreate),
-		Read:   resourceCloudscaleVolumeSnapshotRead,
-		Update: resourceCloudscaleVolumeSnapshotUpdate,
-		Delete: resourceCloudscaleVolumeSnapshotDelete,
+		CreateContext: withLock(volumeSnapshotLockKey, resourceCloudscaleVolumeSnapshotCreate),
+		Read:          resourceCloudscaleVolumeSnapshotRead,
+		UpdateContext: resourceCloudscaleVolumeSnapshotUpdate,
+		DeleteContext: resourceCloudscaleVolumeSnapshotDelete,
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -93,7 +94,7 @@ func getVolumeSnapshotSchema(t SchemaType) map[string]*schema.Schema {
 	return m
 }
 
-func resourceCloudscaleVolumeSnapshotCreate(d *schema.ResourceData, meta any) error {
+func resourceCloudscaleVolumeSnapshotCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	timeout := d.Timeout(schema.TimeoutCreate)
 	startTime := time.Now()
 
@@ -109,9 +110,9 @@ func resourceCloudscaleVolumeSnapshotCreate(d *schema.ResourceData, meta any) er
 
 	log.Printf("[DEBUG] VolumeSnapshot create configuration: %#v", opts)
 
-	snap, err := client.VolumeSnapshots.Create(context.Background(), opts)
+	snap, err := client.VolumeSnapshots.Create(ctx, opts)
 	if err != nil {
-		return fmt.Errorf("Error creating VolumeSnapshot: %s", err)
+		return diag.FromErr(fmt.Errorf("Error creating VolumeSnapshot: %s", err))
 	}
 
 	d.SetId(snap.UUID)
@@ -119,25 +120,21 @@ func resourceCloudscaleVolumeSnapshotCreate(d *schema.ResourceData, meta any) er
 	log.Printf("[INFO] VolumeSnapshot ID: %s", d.Id())
 
 	remainingTime := timeout - time.Since(startTime)
-	_, err = waitForStatus([]string{}, "available", &remainingTime, newVolumeSnapshotRefreshFunc(d, "status", meta))
+	_, err = waitForStatus(ctx, []string{}, "available", &remainingTime, newVolumeSnapshotRefreshFunc(ctx, d, "status", meta))
 	if err != nil {
-		return fmt.Errorf("error waiting for volume snapshot (%s) to become available: %s", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("error waiting for volume snapshot (%s) to become available: %s", d.Id(), err))
 	}
 
-	err = resourceCloudscaleVolumeSnapshotRead(d, meta)
-	if err != nil {
-		return fmt.Errorf("error reading the volume snapshot (%s): %s", d.Id(), err)
-	}
-	return nil
+	return diag.FromErr(resourceCloudscaleVolumeSnapshotRead(d, meta))
 }
 
-func newVolumeSnapshotRefreshFunc(d *schema.ResourceData, attribute string, meta any) resource.StateRefreshFunc {
+func newVolumeSnapshotRefreshFunc(ctx context.Context, d *schema.ResourceData, attribute string, meta any) resource.StateRefreshFunc {
 	client := meta.(*cloudscale.Client)
 	return func() (any, string, error) {
 		id := d.Id()
 
 		// get the instance
-		snap, err := client.VolumeSnapshots.Get(context.Background(), id)
+		snap, err := client.VolumeSnapshots.Get(ctx, id)
 		if err != nil {
 			return nil, "", fmt.Errorf("error retrieving volume snapshot (%s) (refresh) %s", id, err)
 		}
@@ -172,9 +169,9 @@ func readVolumeSnapshot(rId GenericResourceIdentifier, meta any) (*cloudscale.Vo
 	return client.VolumeSnapshots.Get(context.Background(), rId.Id)
 }
 
-func updateVolumeSnapshot(rId GenericResourceIdentifier, meta any, updateRequest *cloudscale.VolumeSnapshotUpdateRequest) error {
+func updateVolumeSnapshot(ctx context.Context, rId GenericResourceIdentifier, meta any, updateRequest *cloudscale.VolumeSnapshotUpdateRequest) error {
 	client := meta.(*cloudscale.Client)
-	return client.VolumeSnapshots.Update(context.Background(), rId.Id, updateRequest)
+	return client.VolumeSnapshots.Update(ctx, rId.Id, updateRequest)
 }
 
 func gatherVolumeSnapshotUpdateRequest(d *schema.ResourceData) []*cloudscale.VolumeSnapshotUpdateRequest {
@@ -196,26 +193,22 @@ func gatherVolumeSnapshotUpdateRequest(d *schema.ResourceData) []*cloudscale.Vol
 	return requests
 }
 
-// volumeSnapshotDeleteTimeout is the SDK default timeout (no Timeouts block is declared
-// for this resource, so d.Timeout would also return this value).
-const volumeSnapshotDeleteTimeout = 20 * time.Minute
-
-func deleteVolumeSnapshot(rId GenericResourceIdentifier, meta any) error {
+func deleteVolumeSnapshot(ctx context.Context, rId GenericResourceIdentifier, meta any) error {
 	client := meta.(*cloudscale.Client)
 
-	if err := client.VolumeSnapshots.Delete(context.Background(), rId.Id); err != nil {
+	if err := client.VolumeSnapshots.Delete(ctx, rId.Id); err != nil {
 		return err
 	}
 	// Unlike most cloudscale resources that disappear immediately after DELETE,
 	// volume snapshots go through a background cleanup period. During this time
 	// the snapshot still exists with status "deleting". We wait for it to be gone.
-	return waitForVolumeSnapshotDeleted(rId.Id, meta, volumeSnapshotDeleteTimeout)
+	return waitForVolumeSnapshotDeleted(ctx, rId.Id, meta)
 }
 
-func waitForVolumeSnapshotDeleted(id string, meta any, remaining time.Duration) error {
+func waitForVolumeSnapshotDeleted(ctx context.Context, id string, meta any) error {
 	client := meta.(*cloudscale.Client)
-	err := waitForDeleted(remaining, func() (exists bool, err error) {
-		snapshot, err := client.VolumeSnapshots.Get(context.Background(), id)
+	err := waitForDeleted(ctx, func() (exists bool, err error) {
+		snapshot, err := client.VolumeSnapshots.Get(ctx, id)
 		if err != nil {
 			if errorResponse, ok := err.(*cloudscale.ErrorResponse); ok && errorResponse.StatusCode == http.StatusNotFound { // API returns 404 once fully deleted
 				return false, nil // gone

--- a/cloudscale/resource_cloudscale_volume_snapshot.go
+++ b/cloudscale/resource_cloudscale_volume_snapshot.go
@@ -30,16 +30,16 @@ func volumeSnapshotLockKey(d *schema.ResourceData) (string, bool) {
 
 var (
 	resourceCloudscaleVolumeSnapshotRead   = getReadOperation(volumeSnapshotHumanName, getGenericResourceIdentifierFromSchema, readVolumeSnapshot, gatherVolumeSnapshotResourceData)
-	resourceCloudscaleVolumeSnapshotUpdate = getUpdateOperation(volumeSnapshotHumanName, getGenericResourceIdentifierFromSchema, updateVolumeSnapshot, resourceCloudscaleVolumeSnapshotRead, gatherVolumeSnapshotUpdateRequest)
-	resourceCloudscaleVolumeSnapshotDelete = getDeleteOperation(volumeSnapshotHumanName, deleteVolumeSnapshot)
+	resourceCloudscaleVolumeSnapshotUpdate = getUpdateOperation(volumeSnapshotHumanName, getGenericResourceIdentifierFromSchema, updateVolumeSnapshot, resourceCloudscaleVolumeSnapshotRead, gatherVolumeSnapshotUpdateRequest, volumeSnapshotLockKey)
+	resourceCloudscaleVolumeSnapshotDelete = getDeleteOperation(volumeSnapshotHumanName, getGenericResourceIdentifierFromSchema, deleteVolumeSnapshot, volumeSnapshotLockKey)
 )
 
 func resourceCloudscaleVolumeSnapshot() *schema.Resource {
 	return &schema.Resource{
 		Create: withLock(volumeSnapshotLockKey, resourceCloudscaleVolumeSnapshotCreate),
 		Read:   resourceCloudscaleVolumeSnapshotRead,
-		Update: withLock(volumeSnapshotLockKey, resourceCloudscaleVolumeSnapshotUpdate),
-		Delete: withLock(volumeSnapshotLockKey, resourceCloudscaleVolumeSnapshotDelete),
+		Update: resourceCloudscaleVolumeSnapshotUpdate,
+		Delete: resourceCloudscaleVolumeSnapshotDelete,
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -196,17 +196,20 @@ func gatherVolumeSnapshotUpdateRequest(d *schema.ResourceData) []*cloudscale.Vol
 	return requests
 }
 
-func deleteVolumeSnapshot(d *schema.ResourceData, meta any) error {
-	client := meta.(*cloudscale.Client)
-	id := d.Id()
+// volumeSnapshotDeleteTimeout is the SDK default timeout (no Timeouts block is declared
+// for this resource, so d.Timeout would also return this value).
+const volumeSnapshotDeleteTimeout = 20 * time.Minute
 
-	if err := client.VolumeSnapshots.Delete(context.Background(), id); err != nil {
+func deleteVolumeSnapshot(rId GenericResourceIdentifier, meta any) error {
+	client := meta.(*cloudscale.Client)
+
+	if err := client.VolumeSnapshots.Delete(context.Background(), rId.Id); err != nil {
 		return err
 	}
 	// Unlike most cloudscale resources that disappear immediately after DELETE,
 	// volume snapshots go through a background cleanup period. During this time
 	// the snapshot still exists with status "deleting". We wait for it to be gone.
-	return waitForVolumeSnapshotDeleted(id, meta, d.Timeout(schema.TimeoutDelete))
+	return waitForVolumeSnapshotDeleted(rId.Id, meta, volumeSnapshotDeleteTimeout)
 }
 
 func waitForVolumeSnapshotDeleted(id string, meta any, remaining time.Duration) error {

--- a/cloudscale/resource_cloudscale_volume_snapshot.go
+++ b/cloudscale/resource_cloudscale_volume_snapshot.go
@@ -25,9 +25,7 @@ func snapshotLockKey(volumeUUID string) string {
 // whole operation, the lock is held through the full create/delete status-wait cycle
 // (see resourceCloudscaleVolumeSnapshotCreate / deleteVolumeSnapshot), ensuring the
 // volume is no longer busy before the next operation on it starts.
-func volumeSnapshotLockKey(d *schema.ResourceData) (string, bool) {
-	return snapshotLockKey(d.Get("source_volume_uuid").(string)), true
-}
+var volumeSnapshotLockKey = uuidLockKey("source_volume_uuid", snapshotLockKey)
 
 var (
 	resourceCloudscaleVolumeSnapshotRead   = getReadOperation(volumeSnapshotHumanName, getGenericResourceIdentifierFromSchema, readVolumeSnapshot, gatherVolumeSnapshotResourceData)

--- a/cloudscale/resource_cloudscale_volume_snapshot.go
+++ b/cloudscale/resource_cloudscale_volume_snapshot.go
@@ -14,6 +14,20 @@ import (
 
 const volumeSnapshotHumanName = "volume snapshot"
 
+func snapshotLockKey(volumeUUID string) string {
+	return fmt.Sprintf("cloudscale/volume-snapshot/%s", volumeUUID)
+}
+
+// volumeSnapshotLockKey serializes snapshot operations on their source volume. The
+// cloudscale API rejects concurrent snapshot operations on the same source volume, so
+// create/update/delete are serialized per volume UUID. Because withLock wraps the
+// whole operation, the lock is held through the full create/delete status-wait cycle
+// (see resourceCloudscaleVolumeSnapshotCreate / deleteVolumeSnapshot), ensuring the
+// volume is no longer busy before the next operation on it starts.
+func volumeSnapshotLockKey(d *schema.ResourceData) (string, bool) {
+	return snapshotLockKey(d.Get("source_volume_uuid").(string)), true
+}
+
 var (
 	resourceCloudscaleVolumeSnapshotRead   = getReadOperation(volumeSnapshotHumanName, getGenericResourceIdentifierFromSchema, readVolumeSnapshot, gatherVolumeSnapshotResourceData)
 	resourceCloudscaleVolumeSnapshotUpdate = getUpdateOperation(volumeSnapshotHumanName, getGenericResourceIdentifierFromSchema, updateVolumeSnapshot, resourceCloudscaleVolumeSnapshotRead, gatherVolumeSnapshotUpdateRequest)
@@ -22,10 +36,10 @@ var (
 
 func resourceCloudscaleVolumeSnapshot() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceCloudscaleVolumeSnapshotCreate,
+		Create: withLock(volumeSnapshotLockKey, resourceCloudscaleVolumeSnapshotCreate),
 		Read:   resourceCloudscaleVolumeSnapshotRead,
-		Update: resourceCloudscaleVolumeSnapshotUpdate,
-		Delete: resourceCloudscaleVolumeSnapshotDelete,
+		Update: withLock(volumeSnapshotLockKey, resourceCloudscaleVolumeSnapshotUpdate),
+		Delete: withLock(volumeSnapshotLockKey, resourceCloudscaleVolumeSnapshotDelete),
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -79,10 +93,6 @@ func getVolumeSnapshotSchema(t SchemaType) map[string]*schema.Schema {
 	return m
 }
 
-func snapshotLockKey(volumeUUID string) string {
-	return fmt.Sprintf("cloudscale/volume-snapshot/%s", volumeUUID)
-}
-
 func resourceCloudscaleVolumeSnapshotCreate(d *schema.ResourceData, meta any) error {
 	timeout := d.Timeout(schema.TimeoutCreate)
 	startTime := time.Now()
@@ -90,13 +100,6 @@ func resourceCloudscaleVolumeSnapshotCreate(d *schema.ResourceData, meta any) er
 	client := meta.(*cloudscale.Client)
 
 	sourceVolumeUUID := d.Get("source_volume_uuid").(string)
-	// The cloudscale API rejects concurrent snapshot operations on the same source
-	// volume. Lock per volume UUID so that if two snapshots of the same volume are
-	// created in the same apply, they are serialized. The lock is held through the
-	// full create + status-wait cycle to ensure the volume is no longer busy before
-	// the next operation starts.
-	globalMu.Lock(snapshotLockKey(sourceVolumeUUID))
-	defer globalMu.Unlock(snapshotLockKey(sourceVolumeUUID))
 
 	opts := &cloudscale.VolumeSnapshotCreateRequest{
 		Name:         d.Get("name").(string),
@@ -196,13 +199,6 @@ func gatherVolumeSnapshotUpdateRequest(d *schema.ResourceData) []*cloudscale.Vol
 func deleteVolumeSnapshot(d *schema.ResourceData, meta any) error {
 	client := meta.(*cloudscale.Client)
 	id := d.Id()
-
-	sourceVolumeUUID := d.Get("source_volume_uuid").(string)
-	// Same API constraint as create: concurrent delete + create (or delete + delete)
-	// on the same source volume are rejected. Lock so that the delete and its
-	// background cleanup wait complete before any subsequent operation on this volume.
-	globalMu.Lock(snapshotLockKey(sourceVolumeUUID))
-	defer globalMu.Unlock(snapshotLockKey(sourceVolumeUUID))
 
 	if err := client.VolumeSnapshots.Delete(context.Background(), id); err != nil {
 		return err

--- a/cloudscale/resources.go
+++ b/cloudscale/resources.go
@@ -9,6 +9,26 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+// getCreateOperation builds a CreateFunc from discrete steps:
+//   - createFunc:    the underlying create implementation
+//   - mutexKeyFunc:  derives a mutex key to serialize concurrent operations; nil = no lock
+func getCreateOperation(
+	createFunc schema.CreateContextFunc,
+	mutexKeyFunc func(d *schema.ResourceData) (string, bool),
+) schema.CreateContextFunc {
+	return func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+		if mutexKeyFunc != nil {
+			if key, ok := mutexKeyFunc(d); ok {
+				if err := globalMu.LockContext(ctx, key); err != nil {
+					return diag.FromErr(err)
+				}
+				defer globalMu.Unlock(key)
+			}
+		}
+		return createFunc(ctx, d, meta)
+	}
+}
+
 // getReadOperation builds a ReadFunc from discrete steps:
 //   - idFunc:      extracts the resource identifier from state
 //   - readFunc:    fetches the resource from the API by that identifier
@@ -108,28 +128,6 @@ func uuidLockKey(attr string, keyFunc func(string) string) func(*schema.Resource
 			return "", false
 		}
 		return keyFunc(uuid.(string)), true
-	}
-}
-
-// withLock wraps a Create/Update/Delete operation so it is serialized on a key derived
-// from the resource data. The cloudscale API rejects many concurrent operations that
-// share some resource (e.g. a parent), so Terraform's parallelism must be serialized on
-// that shared key.
-//
-// mutexKeyFunc derives the lock key from the resource data and returns ok=false when no lock
-// is needed.
-func withLock(
-	mutexKeyFunc func(d *schema.ResourceData) (string, bool),
-	op func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics,
-) func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics {
-	return func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-		if key, ok := mutexKeyFunc(d); ok {
-			if err := globalMu.LockContext(ctx, key); err != nil {
-				return diag.FromErr(err)
-			}
-			defer globalMu.Unlock(key)
-		}
-		return op(ctx, d, meta)
 	}
 }
 

--- a/cloudscale/resources.go
+++ b/cloudscale/resources.go
@@ -1,9 +1,11 @@
 package cloudscale
 
 import (
+	"context"
 	"fmt"
 	"log"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -39,27 +41,29 @@ func getReadOperation[TResource any, TResourceID any](
 func getUpdateOperation[TResourceID any, TRequest any](
 	resourceHumanName string,
 	idFunc func(d *schema.ResourceData) TResourceID,
-	updateFunc func(rId TResourceID, meta any, updateRequest *TRequest) error,
+	updateFunc func(ctx context.Context, rId TResourceID, meta any, updateRequest *TRequest) error,
 	resourceReadFunc schema.ReadFunc,
 	gatherRequestsFunc func(d *schema.ResourceData) []*TRequest,
 	mutexKeyFunc func(d *schema.ResourceData) (string, bool),
-) schema.UpdateFunc {
-	return func(d *schema.ResourceData, meta any) error {
+) schema.UpdateContextFunc {
+	return func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 		if mutexKeyFunc != nil {
 			if key, ok := mutexKeyFunc(d); ok {
-				globalMu.Lock(key)
+				if err := globalMu.LockContext(ctx, key); err != nil {
+					return diag.FromErr(err)
+				}
 				defer globalMu.Unlock(key)
 			}
 		}
 		rId := idFunc(d)
 		updateRequests := gatherRequestsFunc(d)
 		for _, request := range updateRequests {
-			err := updateFunc(rId, meta, request)
+			err := updateFunc(ctx, rId, meta, request)
 			if err != nil {
-				return fmt.Errorf("error updating the %s (%s) status (%s)", resourceHumanName, d.Id(), err)
+				return diag.FromErr(fmt.Errorf("error updating the %s (%s) status (%s)", resourceHumanName, d.Id(), err))
 			}
 		}
-		return resourceReadFunc(d, meta)
+		return diag.FromErr(resourceReadFunc(d, meta))
 	}
 }
 
@@ -70,22 +74,24 @@ func getUpdateOperation[TResourceID any, TRequest any](
 func getDeleteOperation[TResourceID any](
 	resourceHumanName string,
 	idFunc func(d *schema.ResourceData) TResourceID,
-	deleteFunc func(rId TResourceID, meta any) error,
+	deleteFunc func(ctx context.Context, rId TResourceID, meta any) error,
 	mutexKeyFunc func(d *schema.ResourceData) (string, bool),
-) schema.DeleteFunc {
-	return func(d *schema.ResourceData, meta any) error {
+) schema.DeleteContextFunc {
+	return func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 		log.Printf("[INFO] Deleting %s: %s", resourceHumanName, d.Id())
 		if mutexKeyFunc != nil {
 			if key, ok := mutexKeyFunc(d); ok {
-				globalMu.Lock(key)
+				if err := globalMu.LockContext(ctx, key); err != nil {
+					return diag.FromErr(err)
+				}
 				defer globalMu.Unlock(key)
 			}
 		}
 		rId := idFunc(d)
-		err := deleteFunc(rId, meta)
+		err := deleteFunc(ctx, rId, meta)
 
 		if err != nil {
-			return CheckDeleted(d, err, fmt.Sprintf("Error deleting %s", resourceHumanName))
+			return diag.FromErr(CheckDeleted(d, err, fmt.Sprintf("Error deleting %s", resourceHumanName)))
 		}
 		return nil
 	}
@@ -100,14 +106,16 @@ func getDeleteOperation[TResourceID any](
 // is needed.
 func withLock(
 	mutexKeyFunc func(d *schema.ResourceData) (string, bool),
-	op func(d *schema.ResourceData, meta any) error,
-) func(d *schema.ResourceData, meta any) error {
-	return func(d *schema.ResourceData, meta any) error {
+	op func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics,
+) func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics {
+	return func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 		if key, ok := mutexKeyFunc(d); ok {
-			globalMu.Lock(key)
+			if err := globalMu.LockContext(ctx, key); err != nil {
+				return diag.FromErr(err)
+			}
 			defer globalMu.Unlock(key)
 		}
-		return op(d, meta)
+		return op(ctx, d, meta)
 	}
 }
 

--- a/cloudscale/resources.go
+++ b/cloudscale/resources.go
@@ -97,6 +97,20 @@ func getDeleteOperation[TResourceID any](
 	}
 }
 
+// uuidLockKey returns a mutexKeyFunc that derives a lock key from a UUID attribute.
+// If attr is not set — which should never happen for Required attributes — it skips
+// the lock rather than acquiring one on a meaningless empty key.
+func uuidLockKey(attr string, keyFunc func(string) string) func(*schema.ResourceData) (string, bool) {
+	return func(d *schema.ResourceData) (string, bool) {
+		uuid, ok := d.GetOk(attr)
+		if !ok {
+			log.Printf("[WARN] uuidLockKey: %s not set for resource %s, skipping lock", attr, d.Id())
+			return "", false
+		}
+		return keyFunc(uuid.(string)), true
+	}
+}
+
 // withLock wraps a Create/Update/Delete operation so it is serialized on a key derived
 // from the resource data. The cloudscale API rejects many concurrent operations that
 // share some resource (e.g. a parent), so Terraform's parallelism must be serialized on

--- a/cloudscale/resources.go
+++ b/cloudscale/resources.go
@@ -9,27 +9,29 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// mutexKeyFunc derives a mutex key used to serialize concurrent operations on a
-// resource. It returns ok=false to skip locking. It receives ctx and meta so it
-// can, if necessary, resolve the lock key via the API (e.g. a pool member has to
-// look up its pool's load balancer).
-type mutexKeyFunc func(ctx context.Context, d *schema.ResourceData, meta any) (string, bool)
+// mutexKeyFunc derives the key used to serialize concurrent operations on a resource. It returns
+// an error if the key can't be determined, so the operation fails.
+// ctx and meta allow resolving the key via the API (e.g. a pool member looks up its pool's load
+// balancer).
+type mutexKeyFunc func(ctx context.Context, d *schema.ResourceData, meta any) (string, error)
 
 // getCreateOperation builds a CreateFunc from discrete steps:
 //   - createFunc:    the underlying create implementation
-//   - mutexKeyFunc:  derives a mutex key to serialize concurrent operations; nil = no lock
+//   - mutexKeyFunc:  derives the key used to serialize concurrent operations; nil = no lock
 func getCreateOperation(
 	createFunc schema.CreateContextFunc,
 	mutexKeyFunc mutexKeyFunc,
 ) schema.CreateContextFunc {
 	return func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 		if mutexKeyFunc != nil {
-			if key, ok := mutexKeyFunc(ctx, d, meta); ok {
-				if err := globalMu.LockContext(ctx, key); err != nil {
-					return diag.FromErr(err)
-				}
-				defer globalMu.Unlock(key)
+			key, err := mutexKeyFunc(ctx, d, meta)
+			if err != nil {
+				return diag.FromErr(err)
 			}
+			if err := globalMu.LockContext(ctx, key); err != nil {
+				return diag.FromErr(err)
+			}
+			defer globalMu.Unlock(key)
 		}
 		return createFunc(ctx, d, meta)
 	}
@@ -63,7 +65,7 @@ func getReadOperation[TResource any, TResourceID any](
 //   - updateFunc:          sends one update request to the API (called once per request)
 //   - resourceReadFunc:    refreshes state after all updates complete
 //   - gatherRequestsFunc:  builds the list of update requests from changed state
-//   - mutexKeyFunc:        derives a mutex key to serialize concurrent operations; nil = no lock
+//   - mutexKeyFunc:        derives the key used to serialize concurrent operations; nil = no lock
 func getUpdateOperation[TResourceID any, TRequest any](
 	resourceHumanName string,
 	idFunc func(d *schema.ResourceData) TResourceID,
@@ -74,12 +76,14 @@ func getUpdateOperation[TResourceID any, TRequest any](
 ) schema.UpdateContextFunc {
 	return func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 		if mutexKeyFunc != nil {
-			if key, ok := mutexKeyFunc(ctx, d, meta); ok {
-				if err := globalMu.LockContext(ctx, key); err != nil {
-					return diag.FromErr(err)
-				}
-				defer globalMu.Unlock(key)
+			key, err := mutexKeyFunc(ctx, d, meta)
+			if err != nil {
+				return diag.FromErr(err)
 			}
+			if err := globalMu.LockContext(ctx, key); err != nil {
+				return diag.FromErr(err)
+			}
+			defer globalMu.Unlock(key)
 		}
 		rId := idFunc(d)
 		updateRequests := gatherRequestsFunc(d)
@@ -96,7 +100,7 @@ func getUpdateOperation[TResourceID any, TRequest any](
 // getDeleteOperation builds a DeleteFunc from discrete steps:
 //   - idFunc:          extracts the resource identifier from state
 //   - deleteFunc:      calls the API to delete the resource by that identifier
-//   - mutexKeyFunc:    derives a mutex key to serialize concurrent operations; nil = no lock
+//   - mutexKeyFunc:    derives the key used to serialize concurrent operations; nil = no lock
 func getDeleteOperation[TResourceID any](
 	resourceHumanName string,
 	idFunc func(d *schema.ResourceData) TResourceID,
@@ -106,12 +110,14 @@ func getDeleteOperation[TResourceID any](
 	return func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 		log.Printf("[INFO] Deleting %s: %s", resourceHumanName, d.Id())
 		if mutexKeyFunc != nil {
-			if key, ok := mutexKeyFunc(ctx, d, meta); ok {
-				if err := globalMu.LockContext(ctx, key); err != nil {
-					return diag.FromErr(err)
-				}
-				defer globalMu.Unlock(key)
+			key, err := mutexKeyFunc(ctx, d, meta)
+			if err != nil {
+				return diag.FromErr(err)
 			}
+			if err := globalMu.LockContext(ctx, key); err != nil {
+				return diag.FromErr(err)
+			}
+			defer globalMu.Unlock(key)
 		}
 		rId := idFunc(d)
 		err := deleteFunc(ctx, rId, meta)
@@ -123,17 +129,15 @@ func getDeleteOperation[TResourceID any](
 	}
 }
 
-// uuidLockKey returns a mutexKeyFunc that derives a lock key from a UUID attribute.
-// If attr is not set, which should never happen for Required attributes, it skips
-// the lock rather than acquiring one on a meaningless empty key.
+// uuidLockKey derives a lock key from a UUID attribute, returning an error when the attribute is
+// unset.
 func uuidLockKey(attr string, keyFunc func(string) string) mutexKeyFunc {
-	return func(_ context.Context, d *schema.ResourceData, _ any) (string, bool) {
+	return func(_ context.Context, d *schema.ResourceData, _ any) (string, error) {
 		uuid, ok := d.GetOk(attr)
 		if !ok {
-			log.Printf("[WARN] uuidLockKey: %s not set for resource %s, skipping lock", attr, d.Id())
-			return "", false
+			return "", fmt.Errorf("cannot determine lock key: %q is not set", attr)
 		}
-		return keyFunc(uuid.(string)), true
+		return keyFunc(uuid.(string)), nil
 	}
 }
 

--- a/cloudscale/resources.go
+++ b/cloudscale/resources.go
@@ -9,16 +9,22 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+// mutexKeyFunc derives a mutex key used to serialize concurrent operations on a
+// resource. It returns ok=false to skip locking. It receives ctx and meta so it
+// can, if necessary, resolve the lock key via the API (e.g. a pool member has to
+// look up its pool's load balancer).
+type mutexKeyFunc func(ctx context.Context, d *schema.ResourceData, meta any) (string, bool)
+
 // getCreateOperation builds a CreateFunc from discrete steps:
 //   - createFunc:    the underlying create implementation
 //   - mutexKeyFunc:  derives a mutex key to serialize concurrent operations; nil = no lock
 func getCreateOperation(
 	createFunc schema.CreateContextFunc,
-	mutexKeyFunc func(d *schema.ResourceData) (string, bool),
+	mutexKeyFunc mutexKeyFunc,
 ) schema.CreateContextFunc {
 	return func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 		if mutexKeyFunc != nil {
-			if key, ok := mutexKeyFunc(d); ok {
+			if key, ok := mutexKeyFunc(ctx, d, meta); ok {
 				if err := globalMu.LockContext(ctx, key); err != nil {
 					return diag.FromErr(err)
 				}
@@ -64,11 +70,11 @@ func getUpdateOperation[TResourceID any, TRequest any](
 	updateFunc func(ctx context.Context, rId TResourceID, meta any, updateRequest *TRequest) error,
 	resourceReadFunc schema.ReadContextFunc,
 	gatherRequestsFunc func(d *schema.ResourceData) []*TRequest,
-	mutexKeyFunc func(d *schema.ResourceData) (string, bool),
+	mutexKeyFunc mutexKeyFunc,
 ) schema.UpdateContextFunc {
 	return func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 		if mutexKeyFunc != nil {
-			if key, ok := mutexKeyFunc(d); ok {
+			if key, ok := mutexKeyFunc(ctx, d, meta); ok {
 				if err := globalMu.LockContext(ctx, key); err != nil {
 					return diag.FromErr(err)
 				}
@@ -95,12 +101,12 @@ func getDeleteOperation[TResourceID any](
 	resourceHumanName string,
 	idFunc func(d *schema.ResourceData) TResourceID,
 	deleteFunc func(ctx context.Context, rId TResourceID, meta any) error,
-	mutexKeyFunc func(d *schema.ResourceData) (string, bool),
+	mutexKeyFunc mutexKeyFunc,
 ) schema.DeleteContextFunc {
 	return func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 		log.Printf("[INFO] Deleting %s: %s", resourceHumanName, d.Id())
 		if mutexKeyFunc != nil {
-			if key, ok := mutexKeyFunc(d); ok {
+			if key, ok := mutexKeyFunc(ctx, d, meta); ok {
 				if err := globalMu.LockContext(ctx, key); err != nil {
 					return diag.FromErr(err)
 				}
@@ -118,10 +124,10 @@ func getDeleteOperation[TResourceID any](
 }
 
 // uuidLockKey returns a mutexKeyFunc that derives a lock key from a UUID attribute.
-// If attr is not set — which should never happen for Required attributes — it skips
+// If attr is not set, which should never happen for Required attributes, it skips
 // the lock rather than acquiring one on a meaningless empty key.
-func uuidLockKey(attr string, keyFunc func(string) string) func(*schema.ResourceData) (string, bool) {
-	return func(d *schema.ResourceData) (string, bool) {
+func uuidLockKey(attr string, keyFunc func(string) string) mutexKeyFunc {
+	return func(_ context.Context, d *schema.ResourceData, _ any) (string, bool) {
 		uuid, ok := d.GetOk(attr)
 		if !ok {
 			log.Printf("[WARN] uuidLockKey: %s not set for resource %s, skipping lock", attr, d.Id())

--- a/cloudscale/resources.go
+++ b/cloudscale/resources.go
@@ -61,6 +61,26 @@ func getDeleteOperation(
 	}
 }
 
+// withLock wraps a Create/Update/Delete operation so it is serialized on a key derived
+// from the resource data. The cloudscale API rejects many concurrent operations that
+// share some resource (e.g. a parent), so Terraform's parallelism must be serialized on
+// that shared key.
+//
+// keyFunc derives the lock key from the resource data and returns ok=false when no lock
+// is needed.
+func withLock(
+	keyFunc func(d *schema.ResourceData) (string, bool),
+	op func(d *schema.ResourceData, meta any) error,
+) func(d *schema.ResourceData, meta any) error {
+	return func(d *schema.ResourceData, meta any) error {
+		if key, ok := keyFunc(d); ok {
+			globalMu.Lock(key)
+			defer globalMu.Unlock(key)
+		}
+		return op(d, meta)
+	}
+}
+
 type GenericResourceIdentifier struct {
 	Id string
 }

--- a/cloudscale/resources.go
+++ b/cloudscale/resources.go
@@ -7,6 +7,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+// getReadOperation builds a ReadFunc from discrete steps:
+//   - idFunc:      extracts the resource identifier from state
+//   - readFunc:    fetches the resource from the API by that identifier
+//   - gatherFunc:  converts the API response into flat key/value pairs for state
 func getReadOperation[TResource any, TResourceID any](
 	resourceHumanName string,
 	idFunc func(d *schema.ResourceData) TResourceID,
@@ -26,14 +30,27 @@ func getReadOperation[TResource any, TResourceID any](
 	}
 }
 
+// getUpdateOperation builds an UpdateFunc from discrete steps:
+//   - idFunc:              extracts the resource identifier from state
+//   - updateFunc:          sends one update request to the API (called once per request)
+//   - resourceReadFunc:    refreshes state after all updates complete
+//   - gatherRequestsFunc:  builds the list of update requests from changed state
+//   - mutexKeyFunc:        derives a mutex key to serialize concurrent operations; nil = no lock
 func getUpdateOperation[TResourceID any, TRequest any](
 	resourceHumanName string,
 	idFunc func(d *schema.ResourceData) TResourceID,
 	updateFunc func(rId TResourceID, meta any, updateRequest *TRequest) error,
 	resourceReadFunc schema.ReadFunc,
 	gatherRequestsFunc func(d *schema.ResourceData) []*TRequest,
+	mutexKeyFunc func(d *schema.ResourceData) (string, bool),
 ) schema.UpdateFunc {
 	return func(d *schema.ResourceData, meta any) error {
+		if mutexKeyFunc != nil {
+			if key, ok := mutexKeyFunc(d); ok {
+				globalMu.Lock(key)
+				defer globalMu.Unlock(key)
+			}
+		}
 		rId := idFunc(d)
 		updateRequests := gatherRequestsFunc(d)
 		for _, request := range updateRequests {
@@ -46,13 +63,26 @@ func getUpdateOperation[TResourceID any, TRequest any](
 	}
 }
 
-func getDeleteOperation(
+// getDeleteOperation builds a DeleteFunc from discrete steps:
+//   - idFunc:          extracts the resource identifier from state
+//   - deleteFunc:      calls the API to delete the resource by that identifier
+//   - mutexKeyFunc:    derives a mutex key to serialize concurrent operations; nil = no lock
+func getDeleteOperation[TResourceID any](
 	resourceHumanName string,
-	deleteFunc func(d *schema.ResourceData, meta any) error,
+	idFunc func(d *schema.ResourceData) TResourceID,
+	deleteFunc func(rId TResourceID, meta any) error,
+	mutexKeyFunc func(d *schema.ResourceData) (string, bool),
 ) schema.DeleteFunc {
 	return func(d *schema.ResourceData, meta any) error {
 		log.Printf("[INFO] Deleting %s: %s", resourceHumanName, d.Id())
-		err := deleteFunc(d, meta)
+		if mutexKeyFunc != nil {
+			if key, ok := mutexKeyFunc(d); ok {
+				globalMu.Lock(key)
+				defer globalMu.Unlock(key)
+			}
+		}
+		rId := idFunc(d)
+		err := deleteFunc(rId, meta)
 
 		if err != nil {
 			return CheckDeleted(d, err, fmt.Sprintf("Error deleting %s", resourceHumanName))
@@ -66,14 +96,14 @@ func getDeleteOperation(
 // share some resource (e.g. a parent), so Terraform's parallelism must be serialized on
 // that shared key.
 //
-// keyFunc derives the lock key from the resource data and returns ok=false when no lock
+// mutexKeyFunc derives the lock key from the resource data and returns ok=false when no lock
 // is needed.
 func withLock(
-	keyFunc func(d *schema.ResourceData) (string, bool),
+	mutexKeyFunc func(d *schema.ResourceData) (string, bool),
 	op func(d *schema.ResourceData, meta any) error,
 ) func(d *schema.ResourceData, meta any) error {
 	return func(d *schema.ResourceData, meta any) error {
-		if key, ok := keyFunc(d); ok {
+		if key, ok := mutexKeyFunc(d); ok {
 			globalMu.Lock(key)
 			defer globalMu.Unlock(key)
 		}

--- a/cloudscale/resources.go
+++ b/cloudscale/resources.go
@@ -16,15 +16,15 @@ import (
 func getReadOperation[TResource any, TResourceID any](
 	resourceHumanName string,
 	idFunc func(d *schema.ResourceData) TResourceID,
-	readFunc func(rID TResourceID, meta any) (*TResource, error),
+	readFunc func(ctx context.Context, rID TResourceID, meta any) (*TResource, error),
 	gatherFunc func(resource *TResource) ResourceDataRaw,
-) schema.ReadFunc {
-	return func(d *schema.ResourceData, meta any) error {
+) schema.ReadContextFunc {
+	return func(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 		rId := idFunc(d)
-		resource, err := readFunc(rId, meta)
+		resource, err := readFunc(ctx, rId, meta)
 
 		if err != nil {
-			return CheckDeleted(d, err, fmt.Sprintf("Error retrieving %s (%v)", resourceHumanName, rId))
+			return diag.FromErr(CheckDeleted(d, err, fmt.Sprintf("Error retrieving %s (%v)", resourceHumanName, rId)))
 		}
 
 		fillResourceData(d, gatherFunc(resource))
@@ -42,7 +42,7 @@ func getUpdateOperation[TResourceID any, TRequest any](
 	resourceHumanName string,
 	idFunc func(d *schema.ResourceData) TResourceID,
 	updateFunc func(ctx context.Context, rId TResourceID, meta any, updateRequest *TRequest) error,
-	resourceReadFunc schema.ReadFunc,
+	resourceReadFunc schema.ReadContextFunc,
 	gatherRequestsFunc func(d *schema.ResourceData) []*TRequest,
 	mutexKeyFunc func(d *schema.ResourceData) (string, bool),
 ) schema.UpdateContextFunc {
@@ -63,7 +63,7 @@ func getUpdateOperation[TResourceID any, TRequest any](
 				return diag.FromErr(fmt.Errorf("error updating the %s (%s) status (%s)", resourceHumanName, d.Id(), err))
 			}
 		}
-		return diag.FromErr(resourceReadFunc(d, meta))
+		return resourceReadFunc(ctx, d, meta)
 	}
 }
 

--- a/cloudscale/utils_test.go
+++ b/cloudscale/utils_test.go
@@ -1,6 +1,7 @@
 package cloudscale
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -53,8 +54,8 @@ func getPoolId(rs *terraform.ResourceState) LoadBalancerPoolMemberResourceIdenti
 func getTestAccCheckCloudscaleResourceExistsFunc[TResource any, TResourceID any](
 	resourceType string,
 	idFunc func(d *terraform.ResourceState) TResourceID,
-	readFunc func(rId TResourceID, meta any,
-) (*TResource, error)) func(n string, resource *TResource) resource.TestCheckFunc {
+	readFunc func(ctx context.Context, rId TResourceID, meta any) (*TResource, error),
+) func(n string, resource *TResource) resource.TestCheckFunc {
 	return func(
 		n string,
 		resource *TResource,
@@ -69,7 +70,7 @@ func getTestAccCheckCloudscaleResourceExistsFunc[TResource any, TResourceID any]
 			}
 
 			resourceId := idFunc(rs)
-			retrievedResource, err := readFunc(resourceId, testAccProvider.Meta())
+			retrievedResource, err := readFunc(context.Background(), resourceId, testAccProvider.Meta())
 
 			if err != nil {
 				return err
@@ -85,12 +86,12 @@ func getTestAccCheckCloudscaleResourceExistsFunc[TResource any, TResourceID any]
 func getTestAccCheckCloudscaleResourceNotExistsFunc[TResource any, TResourceID any](
 	resourceType string,
 	resourceIdFunc func(resource *TResource) TResourceID,
-	readFunc func(rId TResourceID, meta any) (*TResource, error),
+	readFunc func(ctx context.Context, rId TResourceID, meta any) (*TResource, error),
 ) func(resource *TResource) resource.TestCheckFunc {
 	return func(resource *TResource) resource.TestCheckFunc {
 		return func(s *terraform.State) error {
 			resourceId := resourceIdFunc(resource)
-			_, err := readFunc(resourceId, testAccProvider.Meta())
+			_, err := readFunc(context.Background(), resourceId, testAccProvider.Meta())
 			if err == nil {
 				return fmt.Errorf("%s still exists", resourceType)
 			}

--- a/cloudscale/waitForStatus.go
+++ b/cloudscale/waitForStatus.go
@@ -34,7 +34,7 @@ func waitForStatus(
 }
 
 // waitForDeleted polls existsFunc until the resource is gone. The deadline is
-// carried by ctx — the SDK injects d.Timeout(schema.TimeoutDelete) before
+// carried by ctx: the SDK injects d.Timeout(schema.TimeoutDelete) before
 // calling DeleteContext, so no separate timeout parameter is needed.
 // existsFunc must return (true, nil) while the resource exists,
 // (false, nil) once it is gone, or (_, err) on unexpected errors.

--- a/cloudscale/waitForStatus.go
+++ b/cloudscale/waitForStatus.go
@@ -1,7 +1,7 @@
 package cloudscale
 
 import (
-	"fmt"
+	"context"
 	"math"
 	"time"
 
@@ -9,6 +9,7 @@ import (
 )
 
 func waitForStatus(
+	ctx context.Context,
 	pending []string,
 	target string,
 	timeout *time.Duration,
@@ -29,25 +30,26 @@ func waitForStatus(
 		NotFoundChecks: math.MaxInt32,
 	}
 
-	return stateConf.WaitForState()
+	return stateConf.WaitForStateContext(ctx)
 }
 
-// waitForDeleted polls existsFunc until the resource is gone.
+// waitForDeleted polls existsFunc until the resource is gone. The deadline is
+// carried by ctx — the SDK injects d.Timeout(schema.TimeoutDelete) before
+// calling DeleteContext, so no separate timeout parameter is needed.
 // existsFunc must return (true, nil) while the resource exists,
 // (false, nil) once it is gone, or (_, err) on unexpected errors.
-func waitForDeleted(timeout time.Duration, existsFunc func() (bool, error)) error {
-	deadline := time.Now().Add(timeout)
+func waitForDeleted(ctx context.Context, existsFunc func() (bool, error)) error {
 	time.Sleep(10 * time.Second)
 	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		exists, err := existsFunc()
 		if err != nil {
 			return err
 		}
 		if !exists {
 			return nil
-		}
-		if time.Now().After(deadline) {
-			return fmt.Errorf("timeout: resource still exists after %s", timeout)
 		}
 		time.Sleep(10 * time.Second)
 	}


### PR DESCRIPTION
The cloudscale API fails on many concurrent create/delete operations against the same parent resource. Lock on the parent UUID for pools (keyed on LB), pool members, and listeners (both keyed on pool) to prevent API errors when Terraform parallelizes these operations.